### PR TITLE
feat: add localization and rebrand to Lyra-finAI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json ./
+RUN npm install
+
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM base AS runner
+ENV NODE_ENV=production
+COPY package.json ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+EXPOSE 3000
+CMD ["npm","run","start"]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 <a href="https://badget-eight-gilt.vercel.app/">
-  <h1 align="center">Badget: AI-Powered Financial Management Platform</h1>
+  <h1 align="center">Lyra-finAI: AI-Powered Financial Management Platform</h1>
 </a>
 
- <img width="1440" alt="dashboard_mockup" src="https://github.com/projectx-codehagen/Badget/assets/24507211/2c2b8e43-3d18-4b28-b8d0-5dc0cbdb530f">
+ <img width="1440" alt="dashboard_mockup" src="https://github.com/projectx-codehagen/Lyra-finAI/assets/24507211/2c2b8e43-3d18-4b28-b8d0-5dc0cbdb530f">
 
 <p align="center">
-  Ushering in a new era of financial management with cutting-edge AI. Badget redefines how you track, analyze, and optimize your finances, ensuring smarter, more secure financial decisions.
+  Ushering in a new era of financial management with cutting-edge AI. Lyra-finAI redefines how you track, analyze, and optimize your finances, ensuring smarter, more secure financial decisions.
 </p>
 
 <p align="center">
   <!-- <a href="https://twitter.com/placeholder">
     <img src="https://img.shields.io/twitter/follow/badget?style=flat&label=%40badgety&logo=twitter&color=0bf&logoColor=fff" alt="Twitter" />
   </a> -->
-  <a href="https://github.com/projectx-codehagen/Badget/blob/main/LICENSE.md">
-    <img src="https://img.shields.io/github/license/projectx-codehagen/Badget?label=license&logo=github&color=f80&logoColor=fff" alt="License" />
+  <a href="https://github.com/projectx-codehagen/Lyra-finAI/blob/main/LICENSE.md">
+    <img src="https://img.shields.io/github/license/projectx-codehagen/Lyra-finAI?label=license&logo=github&color=f80&logoColor=fff" alt="License" />
   </a>
 </p>
 
@@ -28,7 +28,7 @@
 
 ## Introduction
 
-Welcome to Badget, the "Copilot for Money" - an AI-powered financial management platform that provides unparalleled insights into your spending habits and financial patterns. Built with a family-first design, Badget empowers households to budget better, track expenses effortlessly, and achieve their financial goals through intelligent automation and real-time insights.
+Welcome to Lyra-finAI, the "Copilot for Money" - an AI-powered financial management platform that provides unparalleled insights into your spending habits and financial patterns. Built with a family-first design, Lyra-finAI empowers households to budget better, track expenses effortlessly, and achieve their financial goals through intelligent automation and real-time insights.
 
 **Key Features:**
 - **Unified Financial Dashboard** - All accounts in one place with smart categorization
@@ -41,7 +41,7 @@ Welcome to Badget, the "Copilot for Money" - an AI-powered financial management 
 
 ## Architecture
 
-Badget implements a **dual-layer architecture** with clean separation between authentication and business logic:
+Lyra-finAI implements a **dual-layer architecture** with clean separation between authentication and business logic:
 
 ### Authentication Layer
 - User identity and session management via **Better-auth**  
@@ -62,7 +62,7 @@ All seamlessly integrated to accelerate financial management innovation.
 
 ## Directory Structure
 
-Badget follows a clean, scalable architecture:
+Lyra-finAI follows a clean, scalable architecture:
 
     .
     ├── src                          # Main project lives here
@@ -85,7 +85,7 @@ Badget follows a clean, scalable architecture:
 Clone & create this repo locally with the following command:
 
 ```bash
-git clone https://github.com/codehagen/Badget
+git clone https://github.com/codehagen/Lyra-finAI
 ```
 
 1. Install dependencies using pnpm:

--- a/README2.md
+++ b/README2.md
@@ -1,12 +1,12 @@
-# Badget - AI-Powered Financial Management Platform
+# Lyra-finAI - AI-Powered Financial Management Platform
 
 > **Ushering in a new era of financial management with cutting-edge AI**
 
-Badget redefines how you track, analyze, and optimize your finances, ensuring smarter, more secure financial decisions. Gain unparalleled insights into your spending habits and financial patterns, empowering you to budget better and experience more.
+Lyra-finAI redefines how you track, analyze, and optimize your finances, ensuring smarter, more secure financial decisions. Gain unparalleled insights into your spending habits and financial patterns, empowering you to budget better and experience more.
 
 ## 🎯 Vision & Value Proposition
 
-Badget aims to be the "Copilot for Money" - an AI-powered financial management platform that provides:
+Lyra-finAI aims to be the "Copilot for Money" - an AI-powered financial management platform that provides:
 
 - **Unified Financial Dashboard** - All accounts in one place via Plaid integration
 - **AI-Driven Insights** - Smart spending analysis, trend detection, and personalized recommendations
@@ -122,7 +122,7 @@ AppUser → Family → FinancialAccount
 
 ### Data Models Integration
 ```typescript
-// Plaid → Badget Mapping
+// Plaid → Lyra-finAI Mapping
 PlaidAccount → FinancialAccount
 PlaidTransaction → Transaction + Category (AI-assigned)
 PlaidBalance → Real-time account balance updates
@@ -291,4 +291,4 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md
 
 ---
 
-**Ready to revolutionize your financial management experience with Badget? Let's build the future of personal finance together!** 🚀
+**Ready to revolutionize your financial management experience with Lyra-finAI? Let's build the future of personal finance together!** 🚀

--- a/STYLING-GUIDE.md
+++ b/STYLING-GUIDE.md
@@ -1,6 +1,6 @@
-"# Badget Design System & Styling Guide
+"# Lyra-finAI Design System & Styling Guide
 
-> A comprehensive guide to the design system, component patterns, and styling conventions used throughout the Badget application.
+> A comprehensive guide to the design system, component patterns, and styling conventions used throughout the Lyra-finAI application.
 
 ## Table of Contents
 
@@ -17,7 +17,7 @@
 ## 🎨 Core Design Principles
 
 ### Color System
-Badget uses a sophisticated **OKLCH color space** with CSS custom properties for consistent theming across light and dark modes.
+Lyra-finAI uses a sophisticated **OKLCH color space** with CSS custom properties for consistent theming across light and dark modes.
 
 #### Light Theme Colors
 ```css
@@ -339,7 +339,7 @@ function CardContent({ className, ...props }) {
 ## 📱 Responsive Design Patterns
 
 ### Breakpoint System
-Badget follows a mobile-first approach with these breakpoints:
+Lyra-finAI follows a mobile-first approach with these breakpoints:
 
 - **Mobile**: Base styles (no prefix) - `0px+`
 - **Small**: `sm:` - `640px+`
@@ -693,4 +693,4 @@ box-shadow: 0 0 0 3px rgb(var(--ring) / 0.5);
 - Leverage CSS custom properties for theme switching
 - Minimize animation complexity for smooth 60fps performance
 
-This styling guide ensures consistent, accessible, and maintainable design patterns throughout the Badget application. All measurements, colors, and patterns are derived from the actual codebase implementation. 
+This styling guide ensures consistent, accessible, and maintainable design patterns throughout the Lyra-finAI application. All measurements, colors, and patterns are derived from the actual codebase implementation. 

--- a/content/blog/advanced-analytics.mdx
+++ b/content/blog/advanced-analytics.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Advanced Analytics for Link Management"
-description: "Dive deep into Badget's analytics features and learn how to optimize your link performance."
+description: "Dive deep into Lyra-finAI's analytics features and learn how to optimize your link performance."
 publishedAt: "2024-01-20"
 summary: "Unlock the power of data-driven link management with advanced analytics insights."
 author: "christerhagen"
@@ -14,16 +14,16 @@ related: ["getting-started"]
   name="Sarah Johnson"
   image="/avatars/sarah.jpg"
   twitter="sarahjdev"
-  bio="Product Manager at Badget with 8+ years in analytics and data visualization. Passionate about turning data into actionable insights."
+  bio="Product Manager at Lyra-finAI with 8+ years in analytics and data visualization. Passionate about turning data into actionable insights."
 />
 
-Understanding your link performance is crucial for making data-driven decisions. Badget's advanced analytics provide deep insights into how your links are performing across different dimensions.
+Understanding your link performance is crucial for making data-driven decisions. Lyra-finAI's advanced analytics provide deep insights into how your links are performing across different dimensions.
 
-If you're new to Badget, start with our [getting started guide](/blog/getting-started) to set up your first links, then return here to master the analytics features.
+If you're new to Lyra-finAI, start with our [getting started guide](/blog/getting-started) to set up your first links, then return here to master the analytics features.
 
 <Image 
   src="/images/analytics-dashboard.png" 
-  alt="Badget Advanced Analytics Dashboard showing click metrics, geographic distribution, and performance trends"
+  alt="Lyra-finAI Advanced Analytics Dashboard showing click metrics, geographic distribution, and performance trends"
   width={800}
   height={500}
 />
@@ -80,7 +80,7 @@ Set up conversion tracking to measure success:
 
 <Image 
   src="/images/conversion-tracking-setup.png" 
-  alt="Conversion tracking setup interface in Badget showing goal configuration and event tracking options"
+  alt="Conversion tracking setup interface in Lyra-finAI showing goal configuration and event tracking options"
   width={750}
   height={450}
 />
@@ -156,7 +156,7 @@ Benchmark your performance:
 
 ## Conclusion
 
-Advanced analytics transform raw data into actionable insights. By leveraging Badget's comprehensive analytics suite, you can optimize your link strategy and achieve better results.
+Advanced analytics transform raw data into actionable insights. By leveraging Lyra-finAI's comprehensive analytics suite, you can optimize your link strategy and achieve better results.
 
 Ready to dive deeper? Explore our [API documentation](/help/api-reference) to integrate analytics into your workflow.
 

--- a/content/blog/getting-started.mdx
+++ b/content/blog/getting-started.mdx
@@ -1,27 +1,27 @@
 ---
-title: "Getting Started with Badget"
-description: "Learn how to get started with Badget, the powerful link management platform."
+title: "Getting Started with Lyra-finAI"
+description: "Learn how to get started with Lyra-finAI, the powerful link management platform."
 publishedAt: "2024-01-15"
-summary: "A comprehensive guide to setting up and using Badget for your link management needs."
+summary: "A comprehensive guide to setting up and using Lyra-finAI for your link management needs."
 author: "christerhagen"
 tags: ["tutorial", "getting-started", "basics"]
 related: ["advanced-analytics"]
 ---
 
-# Getting Started with Badget
+# Getting Started with Lyra-finAI
 
 <Author 
-  name="Badget Team"
+  name="Lyra-finAI Team"
   image="/avatars/team.jpg"
   twitter="badgetapp"
-  bio="The official Badget team account. Building the future of link management with AI-powered insights."
+  bio="The official Lyra-finAI team account. Building the future of link management with AI-powered insights."
 />
 
-Welcome to Badget! This comprehensive guide will help you get up and running with our powerful link management platform.
+Welcome to Lyra-finAI! This comprehensive guide will help you get up and running with our powerful link management platform.
 
-## What is Badget?
+## What is Lyra-finAI?
 
-Badget is a modern link management platform that helps you create, track, and optimize your links. Whether you're a marketer, developer, or content creator, Badget provides the tools you need to manage your links effectively.
+Lyra-finAI is a modern link management platform that helps you create, track, and optimize your links. Whether you're a marketer, developer, or content creator, Lyra-finAI provides the tools you need to manage your links effectively.
 
 ## Key Features
 
@@ -42,7 +42,7 @@ Sign up for a free account at [badget.app](https://badget.app). You can use your
 Once you're logged in, you can create your first shortened link:
 
 ```javascript
-// Using the Badget API
+// Using the Lyra-finAI API
 const response = await fetch('https://api.badget.app/links', {
   method: 'POST',
   headers: {

--- a/content/blog/welcome-to-badget.mdx
+++ b/content/blog/welcome-to-badget.mdx
@@ -1,29 +1,29 @@
 ---
-title: "Welcome to Badget - Building the Future of Link Management"
-description: "An introduction to Badget from the founder, sharing our vision and what makes us different."
+title: "Welcome to Lyra-finAI - Building the Future of Link Management"
+description: "An introduction to Lyra-finAI from the founder, sharing our vision and what makes us different."
 publishedAt: "2024-01-22"
-summary: "A personal message from the founder about Badget's mission and what we're building."
+summary: "A personal message from the founder about Lyra-finAI's mission and what we're building."
 author: "christerhagen"
 tags: ["company", "welcome", "founder"]
 related: ["getting-started"]
 ---
 
-# Welcome to Badget - Building the Future of Link Management
+# Welcome to Lyra-finAI - Building the Future of Link Management
 
-Hey there! I'm Christer, the founder of Badget. I wanted to take a moment to personally welcome you to our platform and share a bit about why we're building Badget.
+Hey there! I'm Christer, the founder of Lyra-finAI. I wanted to take a moment to personally welcome you to our platform and share a bit about why we're building Lyra-finAI.
 
 ## The Problem We're Solving
 
 As someone who's been in the tech industry for years, I've always been frustrated by the complexity of existing link management tools. They're either too simple and lack the features you need, or they're overly complex with pricing that makes your head spin.
 
-I started Badget because I believe link management should be:
+I started Lyra-finAI because I believe link management should be:
 
 - **Simple** - Easy to use without a steep learning curve
 - **Powerful** - Rich analytics and insights when you need them  
 - **Affordable** - Fair pricing that scales with your needs
 - **Beautiful** - A tool you actually enjoy using
 
-## What Makes Badget Different
+## What Makes Lyra-finAI Different
 
 ### AI-Powered Insights
 
@@ -31,7 +31,7 @@ We're not just another link shortener. Our AI analyzes your link performance and
 
 ### Developer-First Approach
 
-As a developer myself, I know how important it is to have robust APIs and integrations. Badget is built API-first, so you can integrate it into any workflow.
+As a developer myself, I know how important it is to have robust APIs and integrations. Lyra-finAI is built API-first, so you can integrate it into any workflow.
 
 ### Focus on Privacy
 
@@ -48,11 +48,11 @@ We're just getting started! Over the coming months, you'll see us ship:
 
 ## Join Us on This Journey
 
-Building a product is a journey, and I'd love for you to be part of it. Whether you're a casual user or managing links for a large organization, your feedback helps shape Badget.
+Building a product is a journey, and I'd love for you to be part of it. Whether you're a casual user or managing links for a large organization, your feedback helps shape Lyra-finAI.
 
 Feel free to reach out to me directly on [Twitter](https://twitter.com/christerhagen) or [LinkedIn](https://linkedin.com/in/christerhagen). I read every message and love hearing from our users.
 
-Thanks for being here, and welcome to Badget!
+Thanks for being here, and welcome to Lyra-finAI!
 
 — Christer
 

--- a/content/help/assets-investments.mdx
+++ b/content/help/assets-investments.mdx
@@ -1,17 +1,17 @@
 ---
 title: "Assets & Investments Tracking"
-description: "Learn how to track your assets, investments, and build comprehensive financial reports in Badget."
+description: "Learn how to track your assets, investments, and build comprehensive financial reports in Lyra-finAI."
 publishedAt: "2024-01-15"
 updatedAt: "2024-01-15"
 tags: ["assets", "investments", "reports", "portfolio"]
 category: "assets"
 readingTime: 9
-summary: "Master asset tracking and investment management in Badget with portfolio monitoring, performance analysis, and comprehensive reporting tools."
+summary: "Master asset tracking and investment management in Lyra-finAI with portfolio monitoring, performance analysis, and comprehensive reporting tools."
 ---
 
 # Assets & Investments Tracking
 
-Building wealth requires careful tracking of your assets and investments. Badget provides comprehensive tools to monitor your portfolio, analyze performance, and generate detailed financial reports.
+Building wealth requires careful tracking of your assets and investments. Lyra-finAI provides comprehensive tools to monitor your portfolio, analyze performance, and generate detailed financial reports.
 
 ## Getting Started with Asset Tracking
 

--- a/content/help/budget-management.mdx
+++ b/content/help/budget-management.mdx
@@ -1,30 +1,30 @@
 ---
-title: "Budget Management in Badget"
-description: "Learn how to create, manage, and optimize your budgets in Badget to achieve your financial goals."
+title: "Budget Management in Lyra-finAI"
+description: "Learn how to create, manage, and optimize your budgets in Lyra-finAI to achieve your financial goals."
 publishedAt: "2024-01-15"
 updatedAt: "2024-01-15"
 tags: ["budget", "planning", "goals", "management"]
 category: "budget"
 readingTime: 8
-summary: "Master budget creation, tracking, and optimization features in Badget to take control of your finances and reach your financial goals."
+summary: "Master budget creation, tracking, and optimization features in Lyra-finAI to take control of your finances and reach your financial goals."
 ---
 
-# Budget Management in Badget
+# Budget Management in Lyra-finAI
 
-Budgets are the foundation of good financial management. Badget provides powerful tools to help you create, track, and optimize your budgets to achieve your financial goals.
+Budgets are the foundation of good financial management. Lyra-finAI provides powerful tools to help you create, track, and optimize your budgets to achieve your financial goals.
 
 ## Creating Your First Budget
 
 ### Getting Started
 
-1. **Navigate to Budgets**: Click on the "Budgets" tab in your Badget dashboard
+1. **Navigate to Budgets**: Click on the "Budgets" tab in your Lyra-finAI dashboard
 2. **Click "Create Budget"**: Start the budget creation process
 3. **Choose Budget Type**: Select from monthly, quarterly, or yearly budgets
 4. **Set Budget Categories**: Define spending categories that matter to you
 
 ### Budget Categories
 
-Badget comes with pre-defined categories, but you can customize them:
+Lyra-finAI comes with pre-defined categories, but you can customize them:
 
 - **Essential Expenses**: Rent, utilities, groceries, insurance
 - **Transportation**: Car payments, gas, public transport
@@ -45,7 +45,7 @@ For each category, you can:
 
 ### Real-Time Monitoring
 
-Badget automatically tracks your spending against your budget:
+Lyra-finAI automatically tracks your spending against your budget:
 
 - **Progress Bars**: Visual representation of spending vs. budget
 - **Color Coding**: Green (under budget), yellow (approaching limit), red (over budget)
@@ -98,7 +98,7 @@ Save time with budget templates:
 
 ### Automation
 
-- **Automatic Categorization**: Let Badget categorize transactions
+- **Automatic Categorization**: Let Lyra-finAI categorize transactions
 - **Recurring Transactions**: Set up automatic budget entries
 - **Smart Alerts**: Customize notifications for your spending style
 
@@ -161,7 +161,7 @@ Need assistance with budget management?
 
 - **In-App Help**: Access contextual help within the budget interface
 - **Video Tutorials**: Watch step-by-step budget creation guides
-- **Community Forum**: Connect with other Badget users
+- **Community Forum**: Connect with other Lyra-finAI users
 - **Support Team**: Contact our team for personalized assistance
 
 Remember, budgeting is a skill that improves with practice. Start with the basics and gradually incorporate more advanced features as you become comfortable with the system.

--- a/content/help/getting-started.mdx
+++ b/content/help/getting-started.mdx
@@ -1,19 +1,19 @@
 ---
-title: "Getting Started with Badget"
-description: "Learn how to get started with Badget and take control of your personal finances."
+title: "Getting Started with Lyra-finAI"
+description: "Learn how to get started with Lyra-finAI and take control of your personal finances."
 publishedAt: "2024-01-15"
 updatedAt: "2024-01-20"
-summary: "A comprehensive guide to help you get up and running with Badget's financial management tools quickly."
+summary: "A comprehensive guide to help you get up and running with Lyra-finAI's financial management tools quickly."
 tags: ["getting-started", "tutorial", "basics", "setup"]
 ---
 
-# Getting Started with Badget
+# Getting Started with Lyra-finAI
 
-Welcome to Badget! This guide will help you get up and running with our comprehensive financial management platform in just a few minutes.
+Welcome to Lyra-finAI! This guide will help you get up and running with our comprehensive financial management platform in just a few minutes.
 
-## What is Badget?
+## What is Lyra-finAI?
 
-Badget is a powerful personal finance platform that helps you budget, track expenses, manage investments, and achieve your financial goals. Whether you're just starting your financial journey or looking to optimize your existing strategy, Badget provides the tools you need to take control of your money.
+Lyra-finAI is a powerful personal finance platform that helps you budget, track expenses, manage investments, and achieve your financial goals. Whether you're just starting your financial journey or looking to optimize your existing strategy, Lyra-finAI provides the tools you need to take control of your money.
 
 ## Creating Your Account
 
@@ -73,7 +73,7 @@ Your dashboard provides a complete overview of your finances:
 - **Quick Actions**: Easily categorize or split transactions
 - **Search & Filter**: Find specific transactions quickly
 
-## Your First Week with Badget
+## Your First Week with Lyra-finAI
 
 ### Day 1-2: Account Setup
 - Complete the setup wizard
@@ -172,6 +172,6 @@ Now that you've set up your account, explore these advanced features:
 
 ## Ready to Take Control?
 
-Your financial future starts today. With Badget's comprehensive tools and guidance, you'll build better money habits, reach your goals faster, and achieve true financial freedom.
+Your financial future starts today. With Lyra-finAI's comprehensive tools and guidance, you'll build better money habits, reach your goals faster, and achieve true financial freedom.
 
 [Log in to your dashboard](https://app.badget.app) and start your journey today!

--- a/content/help/transactions.mdx
+++ b/content/help/transactions.mdx
@@ -1,17 +1,17 @@
 ---
-title: "Managing Transactions in Badget"
-description: "Learn how to record, categorize, and analyze your financial transactions effectively in Badget."
+title: "Managing Transactions in Lyra-finAI"
+description: "Learn how to record, categorize, and analyze your financial transactions effectively in Lyra-finAI."
 publishedAt: "2024-01-15"
 updatedAt: "2024-01-15"
 tags: ["transactions", "expenses", "income", "categorization"]
 category: "transactions"
 readingTime: 7
-summary: "Master transaction management in Badget with automatic imports, smart categorization, and powerful analysis tools."
+summary: "Master transaction management in Lyra-finAI with automatic imports, smart categorization, and powerful analysis tools."
 ---
 
-# Managing Transactions in Badget
+# Managing Transactions in Lyra-finAI
 
-Transactions are the building blocks of your financial data. Badget makes it easy to import, categorize, and analyze all your financial transactions in one place.
+Transactions are the building blocks of your financial data. Lyra-finAI makes it easy to import, categorize, and analyze all your financial transactions in one place.
 
 ## Getting Started with Transactions
 
@@ -37,7 +37,7 @@ For accounts that can't be connected automatically:
 
 ### Default Categories
 
-Badget includes comprehensive pre-built categories:
+Lyra-finAI includes comprehensive pre-built categories:
 
 **Income Categories:**
 - Salary & Wages
@@ -68,7 +68,7 @@ Create categories that fit your unique needs:
 
 ### Automatic Categorization
 
-Badget learns from your categorization patterns:
+Lyra-finAI learns from your categorization patterns:
 
 - **Merchant Recognition**: Automatically categorizes known merchants
 - **Pattern Learning**: Improves accuracy with each manual categorization
@@ -155,7 +155,7 @@ Monitor money in vs. money out:
 
 ### Weekly Reviews
 
-- **Reconcile Accounts**: Compare Badget data with bank statements
+- **Reconcile Accounts**: Compare Lyra-finAI data with bank statements
 - **Review Categories**: Ensure consistent categorization
 - **Check for Duplicates**: Remove any duplicate transactions
 - **Update Recurring**: Adjust recurring transaction schedules
@@ -174,7 +174,7 @@ Monitor money in vs. money out:
 Your transaction data is protected with:
 
 - **256-bit Encryption**: All data encrypted in transit and at rest
-- **Read-Only Access**: Badget can only view, never modify account data
+- **Read-Only Access**: Lyra-finAI can only view, never modify account data
 - **Secure Connections**: Direct, encrypted connections to financial institutions
 - **Regular Audits**: Security practices reviewed by third-party experts
 
@@ -232,6 +232,6 @@ Need help with transaction management?
 - **Help Center**: Search our comprehensive help articles
 - **Video Tutorials**: Watch transaction management guides
 - **Live Chat**: Get real-time help from our support team
-- **Community Forum**: Connect with other Badget users
+- **Community Forum**: Connect with other Lyra-finAI users
 
 Effective transaction management is key to financial success. Start with basic categorization and gradually use more advanced features as you become comfortable with the system.

--- a/content/help/troubleshooting.mdx
+++ b/content/help/troubleshooting.mdx
@@ -1,21 +1,21 @@
 ---
 title: "Troubleshooting Common Issues"
-description: "Solutions to common problems and frequently asked questions about using Badget for financial management."
+description: "Solutions to common problems and frequently asked questions about using Lyra-finAI for financial management."
 publishedAt: "2024-01-25"
 updatedAt: "2024-01-28"
-summary: "Quick solutions and troubleshooting steps for the most common Badget financial management issues."
+summary: "Quick solutions and troubleshooting steps for the most common Lyra-finAI financial management issues."
 tags: ["troubleshooting", "faq", "support", "issues"]
 ---
 
 # Troubleshooting Common Issues
 
-This guide covers solutions to the most frequently encountered issues with Badget's financial management features.
+This guide covers solutions to the most frequently encountered issues with Lyra-finAI's financial management features.
 
 ## Account Connection Issues
 
 ### Bank Account Won't Connect
 
-**Problem**: Unable to link your bank account to Badget.
+**Problem**: Unable to link your bank account to Lyra-finAI.
 
 **Solutions**:
 1. **Verify Credentials**: Ensure username and password are correct
@@ -168,7 +168,7 @@ If description contains "ATM" → Assign to "Cash & ATM"
 
 ### App Loading Slowly
 
-**Problem**: Badget dashboard takes too long to load.
+**Problem**: Lyra-finAI dashboard takes too long to load.
 
 **Solutions**:
 1. **Check Internet Connection**: Verify stable internet connectivity
@@ -272,7 +272,7 @@ When contacting support, please provide:
 
 ### Is my financial data secure?
 
-Yes! Badget uses bank-level security including:
+Yes! Lyra-finAI uses bank-level security including:
 - 256-bit encryption
 - Read-only account access
 - Regular security audits
@@ -285,7 +285,7 @@ Yes! Badget uses bank-level security including:
 - **Investment Accounts**: Daily during market hours
 - **Manual Accounts**: When you update them
 
-### Can I use Badget with international banks?
+### Can I use Lyra-finAI with international banks?
 
 Currently supported countries:
 - United States (all major banks)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/badget
+      BETTER_AUTH_SECRET: changeme
+      BETTER_AUTH_URL: http://localhost:3000
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: badget
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL","pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+volumes:
+  postgres_data:

--- a/docs/ai-budgeting-guide.md
+++ b/docs/ai-budgeting-guide.md
@@ -1,18 +1,18 @@
 # Using AI to Create a Budget
 
-Badget includes automated budgeting features powered by machine learning. These features analyze your transaction history and generate recommended spending plans.
+Lyra-finAI includes automated budgeting features powered by machine learning. These features analyze your transaction history and generate recommended spending plans.
 
 ## Quick Start
 
 1. **Connect your accounts** – Use the Plaid integration to link your bank and credit card data.
 2. **Import transactions** – Transactions are categorized automatically using AI-driven pattern recognition.
-3. **Generate a budget** – From the dashboard, select "Create Budget" to let Badget build a smart spending plan.
+3. **Generate a budget** – From the dashboard, select "Create Budget" to let Lyra-finAI build a smart spending plan.
 4. **Review recommendations** – Budgets adjust dynamically based on new data and your financial goals.
 5. **Track progress** – Monitor spending against AI suggestions and receive alerts when you're off track.
 
 ### How It Works
 
-Badget examines your historical transactions to identify spending patterns. It then provides:
+Lyra-finAI examines your historical transactions to identify spending patterns. It then provides:
 
 - **Smart Budget Creation** – Budgets suggested from past spending habits.
 - **Dynamic Adjustments** – Real‑time budget recommendations as new transactions arrive.
@@ -23,7 +23,7 @@ These capabilities are outlined in the project vision in `README2.md`.
 
 ### Using Vercel AI
 
-Badget can leverage the Vercel AI SDK to run machine learning models in real time using **server actions**.
+Lyra-finAI can leverage the Vercel AI SDK to run machine learning models in real time using **server actions**.
 
 1. Install the Vercel AI SDK: `pnpm add vercel-ai`
 2. Create a server action that sends prompts to your preferred model.
@@ -57,7 +57,7 @@ Each recommendation includes the average monthly spend and a slightly padded bud
 
 ### Advanced AI Features
 
-Badget's AI toolkit goes beyond basic budgeting. Additional server actions expose:
+Lyra-finAI's AI toolkit goes beyond basic budgeting. Additional server actions expose:
 
 - **Anomaly Detection** – `detectTransactionAnomalies()` flags transactions that deviate from historical averages.
 - **Spending Forecasts** – `forecastCategorySpending()` predicts next month's expenses per category.

--- a/docs/financial-integrations-guide.md
+++ b/docs/financial-integrations-guide.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Badget integrates with two major financial data providers to offer comprehensive banking connectivity across different regions:
+Lyra-finAI integrates with two major financial data providers to offer comprehensive banking connectivity across different regions:
 
 - **Plaid**: Covers US, UK, and Canadian financial institutions
 - **GoCardless**: Covers European financial institutions (31 countries, 2,500+ banks)
@@ -34,7 +34,7 @@ User → Select Bank → Plaid Link → Bank Login → Account Selection → Suc
 // Step 1: Create Link Token
 const linkToken = await plaidClient.linkTokenCreate({
   user: { client_user_id: userId },
-  client_name: "Badget",
+  client_name: "Lyra-finAI",
   products: ['transactions', 'accounts'],
   country_codes: ['US', 'GB', 'CA'],
   language: 'en',

--- a/docs/marketing-pages-layout-guide.md
+++ b/docs/marketing-pages-layout-guide.md
@@ -1,6 +1,6 @@
 # Marketing Pages Layout Guide
 
-This guide explains how to create consistent marketing pages using Badget's design system, specifically focusing on the border styling and decorative elements.
+This guide explains how to create consistent marketing pages using Lyra-finAI's design system, specifically focusing on the border styling and decorative elements.
 
 ## Layout Structure
 

--- a/docs/marketing-pages.md
+++ b/docs/marketing-pages.md
@@ -1,6 +1,6 @@
 # Suggested Marketing Pages
 
-This document lists potential marketing pages for Badget. Each page should follow the existing marketing layout located at `src/app/(marketing)/layout.tsx` and use the global colors defined in `src/app/globals.css`.
+This document lists potential marketing pages for Lyra-finAI. Each page should follow the existing marketing layout located at `src/app/(marketing)/layout.tsx` and use the global colors defined in `src/app/globals.css`.
 
 1. **About Us / Mission** – Overview of the company and team.
 2. **Blog / Resources** – Articles on personal finance tips, product updates and announcements.

--- a/src/actions/plaid-actions.ts
+++ b/src/actions/plaid-actions.ts
@@ -49,7 +49,7 @@ export async function createLinkToken() {
 
     const request: LinkTokenCreateRequest = {
       products: [Products.Transactions],
-      client_name: "Badget",
+      client_name: "Lyra-finAI",
       country_codes: [CountryCode.Us],
       language: "en",
       user: {

--- a/src/app/(marketing)/blog/category/[category]/page.tsx
+++ b/src/app/(marketing)/blog/category/[category]/page.tsx
@@ -60,7 +60,7 @@ export async function generateMetadata({
 
   return constructMetadata({
     title: `${categoryDisplay} - Blog`,
-    description: `Browse all ${categoryDisplay.toLowerCase()} articles and tutorials from the Badget team.`,
+    description: `Browse all ${categoryDisplay.toLowerCase()} articles and tutorials from the Lyra-finAI team.`,
   });
 }
 
@@ -106,7 +106,7 @@ export default async function CategoryPage({
             {categoryDisplay}
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Browse all {categoryDisplay.toLowerCase()} articles and tutorials from the Badget team.
+            Browse all {categoryDisplay.toLowerCase()} articles and tutorials from the Lyra-finAI team.
           </p>
           <div className="mt-4">
             <Badge variant="secondary" className="text-sm px-3 py-1">

--- a/src/app/(marketing)/blog/page.tsx
+++ b/src/app/(marketing)/blog/page.tsx
@@ -15,8 +15,8 @@ import { StaticBlogCategoryFilter } from "@/components/blog/static-blog-category
 import { constructMetadata } from "@/lib/construct-metadata";
 
 export const metadata = constructMetadata({
-  title: "Blog - Badget",
-  description: "Insights, tutorials, and updates from the Badget team. Learn how to optimize your link management strategy.",
+  title: "Blog - Lyra-finAI",
+  description: "Insights, tutorials, and updates from the Lyra-finAI team. Learn how to optimize your financial strategy.",
 });
 
 export default function BlogPage() {
@@ -33,8 +33,8 @@ export default function BlogPage() {
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold tracking-tight mb-4">Blog</h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Insights, tutorials, and updates from the Badget team. Learn how to
-            optimize your link management strategy.
+            Insights, tutorials, and updates from the Lyra-finAI team. Learn how
+            to optimize your financial strategy.
           </p>
         </div>
 

--- a/src/app/(marketing)/community/page.tsx
+++ b/src/app/(marketing)/community/page.tsx
@@ -16,7 +16,7 @@ export default function CommunityPage() {
           {/* Header */}
           <div className="text-center space-y-4">
             <h1 className="text-4xl md:text-5xl font-bold tracking-tight">
-              Join the Badget Community
+              Join the Lyra-finAI Community
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
               Connect with us and other users through our social channels. Get
@@ -56,7 +56,7 @@ export default function CommunityPage() {
                 <h3 className="text-xl font-semibold mb-3">Open Source</h3>
                 <p className="text-muted-foreground mb-8">
                   Contribute to our codebase, report issues, or explore how
-                  Badget is built. We welcome all contributions!
+                  Lyra-finAI is built. We welcome all contributions!
                 </p>
               </div>
               <Button asChild className="w-fit" variant="outline">
@@ -75,7 +75,7 @@ export default function CommunityPage() {
                 <h3 className="text-xl font-semibold mb-3">Twitter Updates</h3>
                 <p className="text-muted-foreground mb-8">
                   Follow us for product updates, financial tips, and
-                  behind-the-scenes content from the Badget team.
+                  behind-the-scenes content from the Lyra-finAI team.
                 </p>
               </div>
               <Button asChild className="w-fit" variant="outline">
@@ -109,7 +109,7 @@ export default function CommunityPage() {
           <div className="text-center space-y-4 pt-8 border-t border-border">
             <h2 className="text-lg font-medium">Stay Connected</h2>
             <p className="text-muted-foreground max-w-2xl mx-auto">
-              We&apos;re building Badget in the open and love hearing from our
+              We&apos;re building Lyra-finAI in the open and love hearing from our
               community. Whether you have questions, feedback, or just want to
               say hello, we&apos;re here to help!
             </p>

--- a/src/app/(marketing)/contact/page.tsx
+++ b/src/app/(marketing)/contact/page.tsx
@@ -18,7 +18,7 @@ export default function ContactPage() {
               How can we help?
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Get in touch for support, feedback, or questions about Badget.
+              Get in touch for support, feedback, or questions about Lyra-finAI.
             </p>
           </div>
 
@@ -84,8 +84,8 @@ export default function ContactPage() {
                 </div>
                 <h3 className="text-xl font-semibold mb-3">Developer Docs</h3>
                 <p className="text-muted-foreground mb-8">
-                  Read about Badget platform development and contribute to our
-                  codebase.
+                  Read about Lyra-finAI platform development and contribute to
+                  our codebase.
                 </p>
               </div>
               <Button asChild className="w-fit" variant="outline">

--- a/src/app/(marketing)/help/category/[category]/page.tsx
+++ b/src/app/(marketing)/help/category/[category]/page.tsx
@@ -59,7 +59,7 @@ export async function generateMetadata({
 
   return constructMetadata({
     title: `${categoryDisplay} - Help Center`,
-    description: `Browse all ${categoryDisplay.toLowerCase()} documentation and guides from the Badget team.`,
+    description: `Browse all ${categoryDisplay.toLowerCase()} documentation and guides from the Lyra-finAI team.`,
   });
 }
 
@@ -105,7 +105,7 @@ export default async function HelpCategoryPage({
             {categoryDisplay}
           </h1>
           <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Browse all {categoryDisplay.toLowerCase()} documentation and guides from the Badget team.
+            Browse all {categoryDisplay.toLowerCase()} documentation and guides from the Lyra-finAI team.
           </p>
           <div className="mt-4">
             <Badge variant="secondary" className="text-sm px-3 py-1">

--- a/src/app/(marketing)/help/layout.tsx
+++ b/src/app/(marketing)/help/layout.tsx
@@ -1,8 +1,8 @@
 import { constructMetadata } from "@/lib/construct-metadata";
 
 export const metadata = constructMetadata({
-  title: "Help Center - Badget",
-  description: "Find answers to common questions and learn how to get the most out of Badget.",
+  title: "Help Center - Lyra-finAI",
+  description: "Find answers to common questions and learn how to get the most out of Lyra-finAI.",
 });
 
 export default function HelpLayout({

--- a/src/app/(marketing)/help/page.tsx
+++ b/src/app/(marketing)/help/page.tsx
@@ -41,7 +41,7 @@ const HELP_CATEGORIES: HelpCategory[] = [
     id: "getting-started",
     title: "Getting Started",
     description:
-      "Basic guides and tutorials to help you get up and running with Badget.",
+      "Basic guides and tutorials to help you get up and running with Lyra-finAI.",
     icon: IconBook,
     tags: ["tutorial", "basics", "setup"],
     color: "bg-purple-500/10 text-purple-600 border-purple-200",

--- a/src/app/(marketing)/layout.tsx
+++ b/src/app/(marketing)/layout.tsx
@@ -1,5 +1,6 @@
 import { Navbar } from "@/components/sections/navbar";
 import { FooterSection } from "@/components/sections/footer-section";
+import { MarketingProvider } from "@/lib/marketing-translations";
 
 export default function MarketingLayout({
   children,
@@ -7,12 +8,14 @@ export default function MarketingLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="max-w-7xl mx-auto border-x relative">
-      <div className="block w-px h-full border-l border-border absolute top-0 left-6 z-10"></div>
-      <div className="block w-px h-full border-r border-border absolute top-0 right-6 z-10"></div>
-      <Navbar />
-      {children}
-      <FooterSection />
-    </div>
+    <MarketingProvider>
+      <div className="max-w-7xl mx-auto border-x relative">
+        <div className="block w-px h-full border-l border-border absolute top-0 left-6 z-10"></div>
+        <div className="block w-px h-full border-r border-border absolute top-0 right-6 z-10"></div>
+        <Navbar />
+        {children}
+        <FooterSection />
+      </div>
+    </MarketingProvider>
   );
 }

--- a/src/app/(marketing)/open/page.tsx
+++ b/src/app/(marketing)/open/page.tsx
@@ -31,7 +31,7 @@ export default function OpenStartupPage() {
       <GitHubStatsSection />
 
       <section className="w-full max-w-4xl space-y-4">
-        <h2 className="text-xl font-semibold text-center">Team Badget</h2>
+        <h2 className="text-xl font-semibold text-center">Team Lyra-finAI</h2>
         <Table>
           <TableHeader>
             <TableRow>

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -2,6 +2,7 @@ import { BentoSection } from "@/components/sections/bento-section";
 import { CTASection } from "@/components/sections/cta-section";
 import { FAQSection } from "@/components/sections/faq-section";
 import FeaturesSection from "@/components/sections/features-section";
+import { PricingSection } from "@/components/sections/pricing-section";
 import { HeroSection } from "@/components/sections/hero-section";
 import { QuoteSection } from "@/components/sections/quote-section";
 
@@ -12,6 +13,7 @@ export default function Home() {
       <BentoSection />
       <QuoteSection />
       <FeaturesSection />
+      <PricingSection />
       <FAQSection />
       <CTASection />
     </main>

--- a/src/app/(marketing)/sign-up/page.tsx
+++ b/src/app/(marketing)/sign-up/page.tsx
@@ -1,20 +1,20 @@
 "use client";
 
-import SignIn from "@/components/auth/sign-in";
+import SignUp from "@/components/auth/sign-up";
 import { useMarketingLocale } from "@/lib/marketing-translations";
 
 const copy = {
   en: {
-    title: "Sign in to Lyra-finAI",
-    subtitle: "Welcome back! Enter your credentials to access your dashboard.",
+    title: "Create your Lyra-finAI account",
+    subtitle: "Start for free and experience AI-guided money management in minutes.",
   },
   pt: {
-    title: "Faça login na Lyra-finAI",
-    subtitle: "Bem-vindo de volta! Insira suas credenciais para acessar o painel.",
+    title: "Crie sua conta na Lyra-finAI",
+    subtitle: "Comece grátis e organize suas finanças com IA em poucos minutos.",
   },
 } satisfies Record<"en" | "pt", { title: string; subtitle: string }>;
 
-export default function SignInPage() {
+export default function SignUpPage() {
   const { locale } = useMarketingLocale();
   const content = copy[locale];
 
@@ -26,7 +26,7 @@ export default function SignInPage() {
       <p className="text-muted-foreground mb-8 text-center max-w-md">
         {content.subtitle}
       </p>
-      <SignIn />
+      <SignUp />
     </main>
   );
 }

--- a/src/app/(marketing)/waitlist/page.tsx
+++ b/src/app/(marketing)/waitlist/page.tsx
@@ -4,7 +4,7 @@ export default function WaitlistPage() {
   return (
     <main className="flex flex-col items-center justify-start min-h-[80vh] w-full py-20 px-5">
       <h1 className="text-3xl md:text-4xl font-medium tracking-tight mb-2">
-        Join the Badget Waitlist
+        Join the Lyra-finAI Waitlist
       </h1>
       <p className="text-muted-foreground mb-8 text-center max-w-md">
         Be among the first to experience AI-driven financial management that

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,9 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = constructMetadata({
-  title: "Badget - Makes you save money",
+  title: "Lyra-finAI - Intelligent finance made simple",
   description:
-    "Empower your financial management with AI-driven insights making tracking and optimizing your finances effortless.",
+    "Empower your financial management with AI-driven insights that make tracking and optimizing your finances effortless.",
 });
 
 export default function RootLayout({

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { ImageResponse } from "next/og";
 
 // Configuration exports
 export const runtime = "edge";
-export const alt = "Badget - AI-powered personal finance app";
+export const alt = "Lyra-finAI - AI-powered personal finance app";
 export const size = {
   width: 1200,
   height: 630,

--- a/src/components/growth-section/budget-optimization.tsx
+++ b/src/components/growth-section/budget-optimization.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+const categories = [
+  { name: "Food", current: 75, optimized: 60, color: "bg-blue-500" },
+  { name: "Transport", current: 40, optimized: 35, color: "bg-green-500" },
+  { name: "Entertainment", current: 90, optimized: 70, color: "bg-purple-500" },
+  { name: "Shopping", current: 85, optimized: 65, color: "bg-orange-500" },
+];
+
+export function BudgetOptimizationAnimation() {
+  return (
+    <div className="relative flex size-full items-center justify-center overflow-hidden">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="relative w-full h-full flex items-center justify-center"
+      >
+        <div className="relative w-full max-w-sm space-y-4 p-8">
+          <div className="text-center mb-6">
+            <div className="text-2xl font-semibold text-primary">Budget Optimization</div>
+            <div className="text-sm text-muted-foreground">AI-Powered Recommendations</div>
+          </div>
+          {categories.map((category, index) => (
+            <div key={category.name} className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-primary">{category.name}</span>
+                <span className="text-muted-foreground">${category.optimized}%</span>
+              </div>
+              <div className="relative h-3 bg-muted rounded-full overflow-hidden">
+                <motion.div
+                  className={cn(category.color, "h-full rounded-full")}
+                  initial={{ width: `${category.current}%` }}
+                  animate={{ width: `${category.optimized}%` }}
+                  transition={{ duration: 1.5, delay: index * 0.2, ease: "easeInOut" }}
+                />
+              </div>
+            </div>
+          ))}
+          <div className="mt-6 p-3 bg-accent rounded-lg">
+            <div className="text-sm text-center">
+              <span className="text-secondary font-semibold">+$280</span>
+              <span className="text-muted-foreground"> saved this month</span>
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/growth-section/spending-insights.tsx
+++ b/src/components/growth-section/spending-insights.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+const orbitingItems = [
+  { name: "Coffee", angle: 0, distance: 60, size: 12, color: "bg-yellow-500" },
+  { name: "Groceries", angle: 72, distance: 70, size: 16, color: "bg-green-500" },
+  { name: "Gas", angle: 144, distance: 65, size: 14, color: "bg-red-500" },
+  { name: "Dining", angle: 216, distance: 75, size: 18, color: "bg-blue-500" },
+  { name: "Shopping", angle: 288, distance: 55, size: 10, color: "bg-purple-500" },
+];
+
+const connectingAngles = [0, 72, 144, 216, 288];
+
+export function SpendingInsightsAnimation() {
+  return (
+    <div className="relative flex size-full items-center justify-center overflow-hidden">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+        className="relative w-full h-full flex items-center justify-center"
+      >
+        <div className="relative w-full max-w-sm p-8">
+          <div className="text-center mb-6">
+            <div className="text-2xl font-semibold text-primary">Spending Insights</div>
+            <div className="text-sm text-muted-foreground">Behavioral Pattern Analysis</div>
+          </div>
+          <div className="relative flex items-center justify-center">
+            <div className="w-20 h-20 bg-secondary rounded-full flex items-center justify-center mb-4">
+              <div className="text-white font-bold text-sm">YOU</div>
+            </div>
+            {orbitingItems.map((item, index) => (
+              <motion.div
+                key={item.name}
+                className={cn(
+                  item.color,
+                  "absolute rounded-full flex items-center justify-center text-white text-xs font-medium"
+                )}
+                style={{
+                  width: `${item.size}px`,
+                  height: `${item.size}px`,
+                  left: `calc(50% + ${Math.cos((item.angle * Math.PI) / 180) * item.distance}px)`,
+                  top: `calc(50% + ${Math.sin((item.angle * Math.PI) / 180) * item.distance}px)`,
+                  transform: "translate(-50%, -50%)",
+                }}
+                initial={{ scale: 0, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ duration: 0.5, delay: index * 0.1, ease: "easeOut" }}
+              >
+                {item.name.slice(0, 3)}
+              </motion.div>
+            ))}
+            {connectingAngles.map((angle, index) => (
+              <motion.div
+                key={angle}
+                className="absolute w-px bg-border opacity-30"
+                style={{
+                  height: "80px",
+                  left: "50%",
+                  top: "50%",
+                  transformOrigin: "0 0",
+                  transform: `rotate(${angle}deg)`,
+                }}
+                initial={{ scaleY: 0 }}
+                animate={{ scaleY: 1 }}
+                transition={{ duration: 0.3, delay: 0.5 + index * 0.05, ease: "easeOut" }}
+              />
+            ))}
+          </div>
+          <div className="mt-8 text-center space-y-2">
+            <div className="text-sm text-secondary font-semibold">Pattern Detected</div>
+            <div className="text-xs text-muted-foreground">You spend 40% more on weekends</div>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useMarketingLocale } from "@/lib/marketing-translations";
+
+type LanguageOption = {
+  value: "en" | "pt";
+  label: string;
+};
+
+const options: LanguageOption[] = [
+  { value: "en", label: "EN" },
+  { value: "pt", label: "PT" },
+];
+
+export function LanguageSwitcher() {
+  const { locale, setLocale } = useMarketingLocale();
+
+  return (
+    <div className="relative">
+      <select
+        value={locale}
+        onChange={(event) => setLocale(event.target.value as "en" | "pt")}
+        aria-label="Select language"
+        className="h-9 rounded-full border border-border bg-background px-4 text-sm font-medium text-primary shadow-sm focus:outline-none focus:ring-2 focus:ring-secondary"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/nav-menu.tsx
+++ b/src/components/nav-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 import { motion } from "motion/react";
 import Link from "next/link";
 import React, { useRef, useState } from "react";
@@ -10,8 +10,6 @@ interface NavItem {
   href: string;
 }
 
-const navs: NavItem[] = siteConfig.nav.links;
-
 export function NavMenu() {
   const ref = useRef<HTMLUListElement>(null);
   const [left, setLeft] = useState(0);
@@ -19,11 +17,17 @@ export function NavMenu() {
   const [isReady, setIsReady] = useState(false);
   const [activeSection, setActiveSection] = useState("hero");
   const [isManualScroll, setIsManualScroll] = useState(false);
+  const { nav } = useMarketingContent();
+  const navs: NavItem[] = nav.links;
 
   React.useEffect(() => {
     // Initialize with first nav item
+    const firstAnchor = navs.find((item) => item.href.startsWith("#"));
+    if (!firstAnchor) {
+      return;
+    }
     const firstItem = ref.current?.querySelector(
-      `[href="#${navs[0].href.substring(1)}"]`,
+      `[href="${firstAnchor.href}"]`,
     )?.parentElement;
     if (firstItem) {
       const rect = firstItem.getBoundingClientRect();
@@ -31,14 +35,16 @@ export function NavMenu() {
       setWidth(rect.width);
       setIsReady(true);
     }
-  }, []);
+  }, [navs]);
 
   React.useEffect(() => {
     const handleScroll = () => {
       // Skip scroll handling during manual click scrolling
       if (isManualScroll) return;
 
-      const sections = navs.map((item) => item.href.substring(1));
+      const sections = navs
+        .filter((item) => item.href.startsWith("#"))
+        .map((item) => item.href.substring(1));
 
       // Find the section closest to viewport top
       let closestSection = sections[0];
@@ -71,7 +77,7 @@ export function NavMenu() {
     window.addEventListener("scroll", handleScroll);
     handleScroll(); // Initial check
     return () => window.removeEventListener("scroll", handleScroll);
-  }, [isManualScroll]);
+  }, [isManualScroll, navs]);
 
   const handleClick = (
     e: React.MouseEvent<HTMLAnchorElement>,

--- a/src/components/sections/bento-section.tsx
+++ b/src/components/sections/bento-section.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { SectionHeader } from "@/components/section-header";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 
 export function BentoSection() {
-  const { title, description, items } = siteConfig.bentoSection;
+  const {
+    bentoSection: { title, description, items },
+  } = useMarketingContent();
 
   return (
     <section

--- a/src/components/sections/company-culture-section.tsx
+++ b/src/components/sections/company-culture-section.tsx
@@ -62,7 +62,7 @@ export function CompanyCultureSection() {
 
         <SectionHeader>
           <h2 className="text-3xl md:text-4xl font-medium tracking-tighter text-center text-balance pb-1">
-            Life at Badget
+            Life at Lyra-finAI
           </h2>
           <p className="text-muted-foreground text-center text-balance font-medium">
             We&apos;re builders from all corners of the world who come together

--- a/src/components/sections/cta-section.tsx
+++ b/src/components/sections/cta-section.tsx
@@ -1,9 +1,11 @@
+"use client";
+
 import Image from "next/image";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 import Link from "next/link";
 
 export function CTASection() {
-  const { ctaSection } = siteConfig;
+  const { ctaSection } = useMarketingContent();
 
   return (
     <section

--- a/src/components/sections/faq-section.tsx
+++ b/src/components/sections/faq-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Accordion,
   AccordionContent,
@@ -5,10 +7,10 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { SectionHeader } from "@/components/section-header";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 
 export function FAQSection() {
-  const { faqSection } = siteConfig;
+  const { faqSection } = useMarketingContent();
 
   return (
     <section

--- a/src/components/sections/features-section.tsx
+++ b/src/components/sections/features-section.tsx
@@ -1,10 +1,20 @@
+"use client";
+
 import { SectionHeader } from "@/components/section-header";
 import { cn } from "@/lib/utils";
 import { PiggyBank, BarChart3 } from "lucide-react";
 import Image from "next/image";
 import { ReactNode } from "react";
+import { useMarketingContent } from "@/lib/marketing-translations";
 
 export default function FeaturesSection() {
+  const { featuresSection } = useMarketingContent();
+  const [
+    firstCard = { eyebrow: "", heading: "", body: "" },
+    secondCard = { eyebrow: "", heading: "", body: "" },
+  ] = featuresSection.cards;
+  const metrics = featuresSection.highlight.metrics;
+
   return (
     <section
       id="features"
@@ -17,11 +27,10 @@ export default function FeaturesSection() {
 
         <SectionHeader>
           <h2 className="text-3xl md:text-4xl font-medium tracking-tighter text-center text-balance pb-1">
-            Tailored for Your Financial Success
+            {featuresSection.title}
           </h2>
           <p className="text-muted-foreground text-center text-balance font-medium">
-            Every recommendation, insight, and suggestion is personalized to
-            your unique financial situation and goals.
+            {featuresSection.description}
           </p>
         </SectionHeader>
 
@@ -30,12 +39,12 @@ export default function FeaturesSection() {
             <div className="p-6">
               <span className="text-muted-foreground flex items-center gap-2">
                 <PiggyBank className="size-4" />
-                Custom Budget Optimization
+                {firstCard.eyebrow}
               </span>
               <p className="mt-8 text-2xl font-semibold">
-                AI creates budgets that actually work for your lifestyle,
-                automatically adjusting to help you save more.
+                {firstCard.heading}
               </p>
+              <p className="mt-4 text-sm text-muted-foreground">{firstCard.body}</p>
             </div>
 
             <div className="relative mb-6 border-t border-dashed sm:mb-0 flex-1">
@@ -56,12 +65,12 @@ export default function FeaturesSection() {
             <div className="p-6">
               <span className="text-muted-foreground flex items-center gap-2">
                 <BarChart3 className="size-4" />
-                Behavioral Spending Insights
+                {secondCard.eyebrow}
               </span>
               <p className="mt-8 text-2xl font-semibold">
-                Understand your spending patterns and discover optimization
-                opportunities through AI-powered analysis.
+                {secondCard.heading}
               </p>
+              <p className="mt-4 text-sm text-muted-foreground">{secondCard.body}</p>
             </div>
 
             <div className="relative mb-6 sm:mb-0 flex-1">
@@ -85,28 +94,27 @@ export default function FeaturesSection() {
 
               <div className="relative z-10 p-8 flex flex-col items-center justify-center h-full">
                 <p className="mx-auto mb-8 max-w-md text-balance text-center text-2xl font-semibold text-primary">
-                  AI-powered insights that adapt to your unique financial
-                  patterns and goals.
+                  {featuresSection.highlight.description}
                 </p>
 
                 <div className="flex justify-center gap-6 overflow-hidden">
                   <CircularUI
-                    label="Income"
+                    label={metrics[0]}
                     circles={[{ pattern: "border" }, { pattern: "border" }]}
                   />
 
                   <CircularUI
-                    label="Budget"
+                    label={metrics[1] ?? ""}
                     circles={[{ pattern: "none" }, { pattern: "primary" }]}
                   />
 
                   <CircularUI
-                    label="Savings"
+                    label={metrics[2] ?? ""}
                     circles={[{ pattern: "blue" }, { pattern: "none" }]}
                   />
 
                   <CircularUI
-                    label="Goals"
+                    label={metrics[3] ?? ""}
                     circles={[{ pattern: "primary" }, { pattern: "none" }]}
                     className="hidden sm:block"
                   />

--- a/src/components/sections/footer-section.tsx
+++ b/src/components/sections/footer-section.tsx
@@ -3,11 +3,12 @@
 // import { Icons } from "@/components/icons";
 import { FlickeringGrid } from "@/components/ui/flickering-grid";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 import { ChevronRightIcon } from "@radix-ui/react-icons";
 import Link from "next/link";
 export function FooterSection() {
   const tablet = useMediaQuery("(max-width: 1024px)");
+  const { footer } = useMarketingContent();
 
   return (
     <footer id="footer" className="w-full pb-0">
@@ -15,10 +16,10 @@ export function FooterSection() {
         <div className="flex flex-col items-start justify-start gap-y-5 max-w-xs mx-0">
           <Link href="/" className="flex items-center gap-2">
             {/* <Icons.logo className="size-8" /> */}
-            <p className="text-xl font-semibold text-primary">Badget</p>
+            <p className="text-xl font-semibold text-primary">{footer.brand}</p>
           </Link>
           <p className="tracking-tight text-muted-foreground font-medium">
-            {siteConfig.hero.description}
+            {footer.description}
           </p>
           <div className="flex items-center gap-2 dark:hidden">
             {/* <Icons.soc2 className="size-12" /> */}
@@ -33,7 +34,7 @@ export function FooterSection() {
         </div>
         <div className="pt-5 md:w-1/2">
           <div className="flex flex-col items-start justify-start md:flex-row md:items-center md:justify-between gap-y-5 lg:pl-10">
-            {siteConfig.footerLinks.map((column, columnIndex) => (
+            {footer.columns.map((column, columnIndex) => (
               <ul key={columnIndex} className="flex flex-col gap-y-2">
                 <li className="mb-2 text-sm font-semibold text-primary">
                   {column.title}
@@ -58,7 +59,7 @@ export function FooterSection() {
         <div className="absolute inset-0 bg-gradient-to-t from-transparent to-background z-10 from-40%" />
         <div className="absolute inset-0 mx-6">
           <FlickeringGrid
-            text={tablet ? "Badget" : "Makes you save money"}
+            text={tablet ? footer.marquee.mobile : footer.marquee.desktop}
             fontSize={tablet ? 70 : 90}
             className="h-full w-full"
             squareSize={2}

--- a/src/components/sections/founder-section.tsx
+++ b/src/components/sections/founder-section.tsx
@@ -39,7 +39,7 @@ export function FounderSection() {
                 <p className="text-muted-foreground text-lg leading-relaxed">
                   After struggling with traditional budgeting apps that
                   didn&apos;t work for families, I decided to build something
-                  better. Badget combines AI-powered insights with
+                  better. Lyra-finAI combines AI-powered insights with
                   family-focused design to make financial management intuitive
                   and collaborative.
                 </p>

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -1,9 +1,11 @@
+"use client";
+
 import { HeroVideoSection } from "@/components/sections/hero-video-section";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 import Link from "next/link";
 
 export function HeroSection() {
-  const { hero } = siteConfig;
+  const { hero } = useMarketingContent();
 
   return (
     <section id="hero" className="w-full relative">

--- a/src/components/sections/navbar.tsx
+++ b/src/components/sections/navbar.tsx
@@ -3,7 +3,8 @@
 import { Icons } from "@/components/icons";
 import { NavMenu } from "@/components/nav-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { siteConfig } from "@/lib/config";
+import { LanguageSwitcher } from "@/components/language-switcher";
+import { useMarketingContent } from "@/lib/marketing-translations";
 import { cn } from "@/lib/utils";
 import { Menu, X } from "lucide-react";
 import { AnimatePresence, motion, useScroll } from "motion/react";
@@ -55,12 +56,14 @@ export function Navbar() {
   const [hasScrolled, setHasScrolled] = useState(false);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [activeSection, setActiveSection] = useState("hero");
+  const { nav, hero, footer } = useMarketingContent();
+  const navLinks = nav.links;
 
   useEffect(() => {
     const handleScroll = () => {
-      const sections = siteConfig.nav.links.map((item) =>
-        item.href.substring(1)
-      );
+      const sections = navLinks
+        .filter((item) => item.href.startsWith("#"))
+        .map((item) => item.href.substring(1));
 
       for (const section of sections) {
         const element = document.getElementById(section);
@@ -78,7 +81,7 @@ export function Navbar() {
     handleScroll();
 
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
+  }, [navLinks]);
 
   useEffect(() => {
     const unsubscribe = scrollY.on("change", (latest) => {
@@ -113,7 +116,7 @@ export function Navbar() {
           <div className="flex h-[56px] items-center justify-between p-4">
             <Link href="/" className="flex items-center gap-3">
               {/* <Icons.logo className="size-7 md:size-10" /> */}
-              <p className="text-lg font-semibold text-primary">Badget</p>
+              <p className="text-lg font-semibold text-primary">{footer.brand}</p>
             </Link>
 
             <NavMenu />
@@ -122,11 +125,12 @@ export function Navbar() {
               <div className="flex items-center space-x-6">
                 <Link
                   className="bg-secondary h-8 hidden md:flex items-center justify-center text-sm font-normal tracking-wide rounded-full text-secondary-foreground w-fit px-4 shadow-[inset_0_1px_2px_rgba(255,255,255,0.25),0_3px_3px_-1.5px_rgba(16,24,40,0.06),0_1px_1px_rgba(16,24,40,0.08)] border border-white/[0.12]"
-                  href="/waitlist"
+                  href={hero.cta.primary.href}
                 >
-                  Try for free
+                  {hero.cta.primary.text}
                 </Link>
               </div>
+              <LanguageSwitcher />
               <ThemeToggle />
               <button
                 className="md:hidden border border-border size-8 rounded-md cursor-pointer flex items-center justify-center"
@@ -169,14 +173,17 @@ export function Navbar() {
                 <div className="flex items-center justify-between">
                   <Link href="/" className="flex items-center gap-3">
                     <Icons.logo className="size-7 md:size-10" />
-                    <p className="text-lg font-semibold text-primary">Badget</p>
+                    <p className="text-lg font-semibold text-primary">{footer.brand}</p>
                   </Link>
-                  <button
-                    onClick={toggleDrawer}
-                    className="border border-border rounded-md p-1 cursor-pointer"
-                  >
-                    <X className="size-5" />
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <LanguageSwitcher />
+                    <button
+                      onClick={toggleDrawer}
+                      className="border border-border rounded-md p-1 cursor-pointer"
+                    >
+                      <X className="size-5" />
+                    </button>
+                  </div>
                 </div>
 
                 <motion.ul
@@ -184,7 +191,7 @@ export function Navbar() {
                   variants={drawerMenuContainerVariants}
                 >
                   <AnimatePresence>
-                    {siteConfig.nav.links.map((item) => (
+                    {navLinks.map((item) => (
                       <motion.li
                         key={item.id}
                         className="p-2.5 border-b border-border last:border-b-0"

--- a/src/components/sections/pricing-section.tsx
+++ b/src/components/sections/pricing-section.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { SectionHeader } from "@/components/section-header";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 import { cn } from "@/lib/utils";
 import { motion } from "motion/react";
+import Link from "next/link";
 import { useState } from "react";
 
 interface TabsProps {
@@ -67,12 +68,14 @@ export function PricingSection() {
   const [billingCycle, setBillingCycle] = useState<"monthly" | "yearly">(
     "monthly",
   );
+  const { pricing } = useMarketingContent();
+  const pricingItems = pricing.pricingItems;
 
   // Update price animation
   const PriceDisplay = ({
     tier,
   }: {
-    tier: (typeof siteConfig.pricing.pricingItems)[0];
+    tier: (typeof pricing.pricingItems)[number];
   }) => {
     const price = billingCycle === "yearly" ? tier.yearlyPrice : tier.price;
 
@@ -100,10 +103,10 @@ export function PricingSection() {
     >
       <SectionHeader>
         <h2 className="text-3xl md:text-4xl font-medium tracking-tighter text-center text-balance">
-          {siteConfig.pricing.title}
+          {pricing.title}
         </h2>
         <p className="text-muted-foreground text-center text-balance font-medium">
-          {siteConfig.pricing.description}
+          {pricing.description}
         </p>
       </SectionHeader>
       <div className="relative w-full h-full">
@@ -116,7 +119,7 @@ export function PricingSection() {
         </div>
 
         <div className="grid min-[650px]:grid-cols-2 min-[900px]:grid-cols-3 gap-4 w-full max-w-6xl mx-auto px-6">
-          {siteConfig.pricing.pricingItems.map((tier) => (
+          {pricingItems.map((tier) => (
             <div
               key={tier.name}
               className={cn(
@@ -145,22 +148,21 @@ export function PricingSection() {
               </div>
 
               <div className="flex flex-col gap-2 p-4">
-                <button
-                  className={`h-10 w-full flex items-center justify-center text-sm font-normal tracking-wide rounded-full px-4 cursor-pointer transition-all ease-out active:scale-95 ${
+                <Link
+                  href={tier.href}
+                  className={`h-10 w-full flex items-center justify-center text-sm font-normal tracking-wide rounded-full px-4 transition-all ease-out active:scale-95 ${
                     tier.isPopular
                       ? `${tier.buttonColor} shadow-[inset_0_1px_2px_rgba(255,255,255,0.25),0_3px_3px_-1.5px_rgba(16,24,40,0.06),0_1px_1px_rgba(16,24,40,0.08)]`
                       : `${tier.buttonColor} shadow-[0px_1px_2px_0px_rgba(255,255,255,0.16)_inset,0px_3px_3px_-1.5px_rgba(16,24,40,0.24),0px_1px_1px_-0.5px_rgba(16,24,40,0.20)]`
                   }`}
                 >
                   {tier.buttonText}
-                </button>
+                </Link>
               </div>
               <hr className="border-border dark:border-white/20" />
               <div className="p-4">
-                {tier.name !== "Basic" && (
-                  <p className="text-sm mb-4">
-                    Everything in {tier.name === "Pro" ? "Basic" : "Pro"} +
-                  </p>
+                {tier.included && (
+                  <p className="text-sm mb-4">{tier.included}</p>
                 )}
                 <ul className="space-y-3">
                   {tier.features.map((feature) => (

--- a/src/components/sections/quote-section.tsx
+++ b/src/components/sections/quote-section.tsx
@@ -1,11 +1,13 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
 import { Calendar, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { SectionHeader } from "@/components/section-header";
-import { siteConfig } from "@/lib/config";
+import { useMarketingContent } from "@/lib/marketing-translations";
 
 export function QuoteSection() {
-  const { quoteSection } = siteConfig;
+  const { quoteSection } = useMarketingContent();
 
   return (
     <section

--- a/src/components/sections/what-is-badget-section.tsx
+++ b/src/components/sections/what-is-badget-section.tsx
@@ -13,10 +13,10 @@ export function WhatIsBadgetSection() {
 
         <SectionHeader>
           <h2 className="text-3xl md:text-4xl font-medium tracking-tighter text-center text-balance pb-1">
-            What is Badget?
+            What is Lyra-finAI?
           </h2>
           <p className="text-muted-foreground text-center text-balance font-medium">
-            Badget is a modern, open-source AI-powered personal finance
+            Lyra-finAI is a modern, open-source AI-powered personal finance
             platform. We power smart budgets, spending insights, and predictive
             analytics tailored for 1,000+ families globally.
           </p>
@@ -37,7 +37,7 @@ export function WhatIsBadgetSection() {
               <div className="space-y-4">
                 <h3 className="text-xl font-semibold">Family-First Design</h3>
                 <p className="text-muted-foreground">
-                  Built specifically for families, Badget helps you manage
+                  Built specifically for families, Lyra-finAI helps you manage
                   shared expenses, set family budgets, and teach financial
                   literacy to the next generation through intuitive tools and
                   dashboards.

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -16,7 +16,7 @@ export function SiteHeader() {
         <div className="ml-auto flex items-center gap-2">
           <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
             <a
-              href="https://github.com/Codehagen/Badget"
+              href="https://github.com/Codehagen/Lyra-finAI"
               rel="noopener noreferrer"
               target="_blank"
               className="text-foreground"

--- a/src/components/waitlist-form.tsx
+++ b/src/components/waitlist-form.tsx
@@ -52,7 +52,7 @@ export function WaitlistForm() {
         <h3 className="text-xl font-medium">You&apos;re on the waitlist!</h3>
         <p className="text-muted-foreground">
           Thanks for joining! We&apos;ll keep you updated on our progress and
-          notify you when Badget is ready.
+          notify you when Lyra-finAI is ready.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full">
           <Button

--- a/src/data/authors.ts
+++ b/src/data/authors.ts
@@ -6,16 +6,16 @@ export const authors: Record<string, Author> = {
     name: "Christer Hagen",
     defaultTitle: "Founder & CEO",
     image: "/avatars/christer.jpg",
-    bio: "Founder of Badget, passionate about building tools that help people manage their digital life more effectively.",
+    bio: "Founder of Lyra-finAI, passionate about building tools that help people manage their digital life more effectively.",
     twitter: "christerhagen",
     linkedin: "christerhagen",
   },
   "badget-team": {
     id: "badget-team",
-    name: "Badget Team",
+    name: "Lyra-finAI Team",
     defaultTitle: "Product Team",
     image: "/avatars/team.jpg",
-    bio: "The official Badget team account. Building the future of link management with AI-powered insights.",
+    bio: "The official Lyra-finAI team account. Building the future of link management with AI-powered insights.",
     twitter: "badgetapp",
   },
   "sarah-johnson": {
@@ -23,7 +23,7 @@ export const authors: Record<string, Author> = {
     name: "Sarah Johnson",
     defaultTitle: "Product Manager",
     image: "/avatars/sarah.jpg",
-    bio: "Product Manager at Badget with 8+ years in analytics and data visualization. Passionate about turning data into actionable insights.",
+    bio: "Product Manager at Lyra-finAI with 8+ years in analytics and data visualization. Passionate about turning data into actionable insights.",
     twitter: "sarahjdev",
   },
 };

--- a/src/lib/config.tsx
+++ b/src/lib/config.tsx
@@ -1,9 +1,10 @@
 import { FirstBentoAnimation } from "@/components/first-bento-animation";
 import { FourthBentoAnimation } from "@/components/fourth-bento-animation";
+import { BudgetOptimizationAnimation } from "@/components/growth-section/budget-optimization";
+import { SpendingInsightsAnimation } from "@/components/growth-section/spending-insights";
 import { SecondBentoAnimation } from "@/components/second-bento-animation";
 import { ThirdBentoAnimation } from "@/components/third-bento-animation";
 import { cn } from "@/lib/utils";
-import { motion } from "motion/react";
 
 export const Highlight = ({
   children,
@@ -27,7 +28,7 @@ export const Highlight = ({
 export const BLUR_FADE_DELAY = 0.15;
 
 export const siteConfig = {
-  name: "Badget",
+  name: "Lyra-finAI",
   description:
     "AI-powered personal finance app that turns raw transactions into real-time spending insights, predictive budgets & holistic financial health scores.",
   cta: "Get Started",
@@ -43,7 +44,7 @@ export const siteConfig = {
     "Expense Insights",
   ],
   links: {
-    email: "support@badget.tech",
+    email: "support@lyra-finai.com",
     twitter: "https://tx.com/codehagen",
     discord: "https://discord.gg/TK7k6uY4",
     github: "https://github.com/codehagen",
@@ -75,15 +76,15 @@ export const siteConfig = {
     badge: "AI-powered financial insights",
     title: "Master Your Money With AI",
     description:
-      "Badget turns raw transactions into real-time spending insights, predictive budgets, and a holistic financial health score. Spend smarter, save faster.",
+      "Lyra-finAI turns raw transactions into real-time spending insights, predictive budgets, and a holistic financial health score. Spend smarter, save faster.",
     cta: {
       primary: {
-        text: "Join Waitlist",
-        href: "/waitlist",
+        text: "Try for Free",
+        href: "/sign-up",
       },
       secondary: {
-        text: "Log in",
-        href: "/waitlist",
+        text: "Sign In",
+        href: "/sign-in",
       },
     },
   },
@@ -291,7 +292,7 @@ export const siteConfig = {
   featureSection: {
     title: "Simple. Smart. Secure.",
     description:
-      "Discover how Badget transforms your financial data into actionable insights in four easy steps",
+      "Discover how Lyra-finAI transforms your financial data into actionable insights in four easy steps",
     items: [
       {
         id: 1,
@@ -398,216 +399,14 @@ export const siteConfig = {
     items: [
       {
         id: 1,
-        content: (
-          <div className="relative flex size-full items-center justify-center overflow-hidden">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.5, ease: "easeOut" }}
-              className="relative w-full h-full flex items-center justify-center"
-            >
-              {/* Animated Budget Bars */}
-              <div className="relative w-full max-w-sm space-y-4 p-8">
-                <div className="text-center mb-6">
-                  <div className="text-2xl font-semibold text-primary">
-                    Budget Optimization
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    AI-Powered Recommendations
-                  </div>
-                </div>
-
-                {/* Budget Categories */}
-                {[
-                  {
-                    name: "Food",
-                    current: 75,
-                    optimized: 60,
-                    color: "bg-blue-500",
-                  },
-                  {
-                    name: "Transport",
-                    current: 40,
-                    optimized: 35,
-                    color: "bg-green-500",
-                  },
-                  {
-                    name: "Entertainment",
-                    current: 90,
-                    optimized: 70,
-                    color: "bg-purple-500",
-                  },
-                  {
-                    name: "Shopping",
-                    current: 85,
-                    optimized: 65,
-                    color: "bg-orange-500",
-                  },
-                ].map((category, index) => (
-                  <div key={category.name} className="space-y-2">
-                    <div className="flex justify-between text-sm">
-                      <span className="text-primary">{category.name}</span>
-                      <span className="text-muted-foreground">
-                        ${category.optimized}%
-                      </span>
-                    </div>
-                    <div className="relative h-3 bg-muted rounded-full overflow-hidden">
-                      <motion.div
-                        className={cn(category.color, "h-full rounded-full")}
-                        initial={{ width: `${category.current}%` }}
-                        animate={{ width: `${category.optimized}%` }}
-                        transition={{
-                          duration: 1.5,
-                          delay: index * 0.2,
-                          ease: "easeInOut",
-                        }}
-                      />
-                    </div>
-                  </div>
-                ))}
-
-                <div className="mt-6 p-3 bg-accent rounded-lg">
-                  <div className="text-sm text-center">
-                    <span className="text-secondary font-semibold">+$280</span>
-                    <span className="text-muted-foreground">
-                      {" "}
-                      saved this month
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </motion.div>
-          </div>
-        ),
+        content: <BudgetOptimizationAnimation />,
         title: "Custom Budget Optimization",
         description:
           "AI creates budgets that actually work for your lifestyle, automatically adjusting to help you save more without sacrificing what matters most.",
       },
       {
         id: 2,
-        content: (
-          <div className="relative flex size-full items-center justify-center overflow-hidden">
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.5, ease: "easeOut" }}
-              className="relative w-full h-full flex items-center justify-center"
-            >
-              {/* Spending Pattern Visualization */}
-              <div className="relative w-full max-w-sm p-8">
-                <div className="text-center mb-6">
-                  <div className="text-2xl font-semibold text-primary">
-                    Spending Insights
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    Behavioral Pattern Analysis
-                  </div>
-                </div>
-
-                {/* Central Node */}
-                <div className="relative flex items-center justify-center">
-                  <div className="w-20 h-20 bg-secondary rounded-full flex items-center justify-center mb-4">
-                    <div className="text-white font-bold text-sm">YOU</div>
-                  </div>
-
-                  {/* Orbiting Spending Categories */}
-                  {[
-                    {
-                      name: "Coffee",
-                      angle: 0,
-                      distance: 60,
-                      size: 12,
-                      color: "bg-yellow-500",
-                    },
-                    {
-                      name: "Groceries",
-                      angle: 72,
-                      distance: 70,
-                      size: 16,
-                      color: "bg-green-500",
-                    },
-                    {
-                      name: "Gas",
-                      angle: 144,
-                      distance: 65,
-                      size: 14,
-                      color: "bg-red-500",
-                    },
-                    {
-                      name: "Dining",
-                      angle: 216,
-                      distance: 75,
-                      size: 18,
-                      color: "bg-blue-500",
-                    },
-                    {
-                      name: "Shopping",
-                      angle: 288,
-                      distance: 55,
-                      size: 10,
-                      color: "bg-purple-500",
-                    },
-                  ].map((item, index) => (
-                    <motion.div
-                      key={item.name}
-                      className={cn(
-                        item.color,
-                        "absolute rounded-full flex items-center justify-center text-white text-xs font-medium"
-                      )}
-                      style={{
-                        width: `${item.size}px`,
-                        height: `${item.size}px`,
-                        left: `calc(50% + ${Math.cos((item.angle * Math.PI) / 180) * item.distance}px)`,
-                        top: `calc(50% + ${Math.sin((item.angle * Math.PI) / 180) * item.distance}px)`,
-                        transform: "translate(-50%, -50%)",
-                      }}
-                      initial={{ scale: 0, opacity: 0 }}
-                      animate={{ scale: 1, opacity: 1 }}
-                      transition={{
-                        duration: 0.5,
-                        delay: index * 0.1,
-                        ease: "easeOut",
-                      }}
-                    >
-                      {item.name.slice(0, 3)}
-                    </motion.div>
-                  ))}
-
-                  {/* Connecting Lines */}
-                  {[0, 72, 144, 216, 288].map((angle, index) => (
-                    <motion.div
-                      key={angle}
-                      className="absolute w-px bg-border opacity-30"
-                      style={{
-                        height: "80px",
-                        left: "50%",
-                        top: "50%",
-                        transformOrigin: "0 0",
-                        transform: `rotate(${angle}deg)`,
-                      }}
-                      initial={{ scaleY: 0 }}
-                      animate={{ scaleY: 1 }}
-                      transition={{
-                        duration: 0.3,
-                        delay: 0.5 + index * 0.05,
-                        ease: "easeOut",
-                      }}
-                    />
-                  ))}
-                </div>
-
-                <div className="mt-8 text-center space-y-2">
-                  <div className="text-sm text-secondary font-semibold">
-                    Pattern Detected
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    You spend 40% more on weekends
-                  </div>
-                </div>
-              </div>
-            </motion.div>
-          </div>
-        ),
+        content: <SpendingInsightsAnimation />,
         title: "Behavioral Spending Insights",
         description:
           "Understand your spending patterns and discover optimization opportunities through AI-powered behavioral analysis of your financial habits.",
@@ -621,7 +420,7 @@ export const siteConfig = {
       "Join thousands of users who have improved their financial health with AI-powered insights and predictive budgeting.",
     primaryButton: {
       text: "Start Your Free Journey",
-      href: "/waitlist",
+      href: "/sign-up",
     },
     secondaryButton: {
       text: "Talk to Founder",
@@ -635,7 +434,7 @@ export const siteConfig = {
     pricingItems: [
       {
         name: "Free",
-        href: "#",
+        href: "/sign-up",
         price: "$0",
         period: "month",
         yearlyPrice: "$0",
@@ -652,7 +451,7 @@ export const siteConfig = {
       },
       {
         name: "Premium",
-        href: "#",
+        href: "/sign-up",
         price: "$9",
         period: "month",
         yearlyPrice: "$90",
@@ -674,7 +473,7 @@ export const siteConfig = {
       },
       {
         name: "Family",
-        href: "#",
+        href: "/sign-up",
         price: "$19",
         period: "month",
         yearlyPrice: "$190",
@@ -701,7 +500,7 @@ export const siteConfig = {
       img: "https://randomuser.me/api/portraits/men/91.jpg",
       description: (
         <p>
-          Badget&apos;s AI-driven spending analysis has transformed how I help
+          Lyra-finAI&apos;s AI-driven spending analysis has transformed how I help
           clients manage their finances.
           <Highlight>
             Insights are now more accurate and actionable than ever.
@@ -713,11 +512,11 @@ export const siteConfig = {
     {
       id: "2",
       name: "Samantha Lee",
-      role: "Working Mom & Badget User",
+      role: "Working Mom & Lyra-finAI User",
       img: "https://randomuser.me/api/portraits/women/12.jpg",
       description: (
         <p>
-          Using Badget&apos;s predictive budgeting has completely changed our
+          Using Lyra-finAI&apos;s predictive budgeting has completely changed our
           family&apos;s financial planning.
           <Highlight>We&apos;re saving 40% more each month!</Highlight> Highly
           recommend to any family wanting financial clarity.
@@ -732,7 +531,7 @@ export const siteConfig = {
       description: (
         <p>
           As a business owner, I need to track both personal and business
-          expenses. Badget&apos;s AI categorization does this perfectly.
+          expenses. Lyra-finAI&apos;s AI categorization does this perfectly.
           <Highlight>My financial organization has doubled.</Highlight>{" "}
           Essential tool for entrepreneurs.
         </p>
@@ -898,43 +697,43 @@ export const siteConfig = {
   faqSection: {
     title: "Frequently Asked Questions",
     description:
-      "Answers to common questions about Badget and its features. If you have any other questions, please don't hesitate to contact us.",
+      "Answers to common questions about Lyra-finAI and its features. If you have any other questions, please don't hesitate to contact us.",
     faQitems: [
       {
         id: 1,
-        question: "What is Badget?",
+        question: "What is Lyra-finAI?",
         answer:
-          "Badget is an AI-powered personal finance app that transforms your raw transaction data into actionable insights. It creates predictive budgets, tracks spending patterns, and provides a comprehensive financial health score to help you make smarter money decisions.",
+          "Lyra-finAI is an AI-powered personal finance app that transforms your raw transaction data into actionable insights. It creates predictive budgets, tracks spending patterns, and provides a comprehensive financial health score to help you make smarter money decisions.",
       },
       {
         id: 2,
-        question: "How does Badget analyze my spending?",
+        question: "How does Lyra-finAI analyze my spending?",
         answer:
-          "Badget uses advanced AI algorithms to categorize your transactions, identify spending patterns, detect unusual purchases, and predict future cash flow. It learns from your financial behavior to provide increasingly personalized insights and recommendations.",
+          "Lyra-finAI uses advanced AI algorithms to categorize your transactions, identify spending patterns, detect unusual purchases, and predict future cash flow. It learns from your financial behavior to provide increasingly personalized insights and recommendations.",
       },
       {
         id: 3,
         question: "Is my financial data secure?",
         answer:
-          "Yes, Badget uses bank-grade encryption and security measures that meet or exceed industry standards. We employ end-to-end encryption, secure data centers, and never store your banking credentials. Your data is protected with the same level of security used by major financial institutions.",
+          "Yes, Lyra-finAI uses bank-grade encryption and security measures that meet or exceed industry standards. We employ end-to-end encryption, secure data centers, and never store your banking credentials. Your data is protected with the same level of security used by major financial institutions.",
       },
       {
         id: 4,
         question: "Which banks and accounts can I connect?",
         answer:
-          "Badget supports connections to over 10,000 financial institutions including major banks, credit unions, credit cards, investment accounts, and crypto wallets. We use secure API connections that never require sharing your login credentials.",
+          "Lyra-finAI supports connections to over 10,000 financial institutions including major banks, credit unions, credit cards, investment accounts, and crypto wallets. We use secure API connections that never require sharing your login credentials.",
       },
       {
         id: 5,
         question: "Is there a free version available?",
         answer:
-          "Yes, Badget offers a free tier that includes basic spending insights, simple budget tracking, and monthly financial health scores. You can connect up to 2 accounts and access core features without any cost.",
+          "Yes, Lyra-finAI offers a free tier that includes basic spending insights, simple budget tracking, and monthly financial health scores. You can connect up to 2 accounts and access core features without any cost.",
       },
       {
         id: 6,
-        question: "How does Badget help me save money?",
+        question: "How does Lyra-finAI help me save money?",
         answer:
-          "Badget identifies spending patterns, suggests budget optimizations, alerts you to unusual expenses, and provides predictive insights about your financial future. Many users save 20-30% more each month by following Badget's AI-powered recommendations.",
+          "Lyra-finAI identifies spending patterns, suggests budget optimizations, alerts you to unusual expenses, and provides predictive insights about your financial future. Many users save 20-30% more each month by following Lyra-finAI's AI-powered recommendations.",
       },
     ],
   },
@@ -944,7 +743,7 @@ export const siteConfig = {
     backgroundImage: "/cta-background.png",
     button: {
       text: "Start Your Free Financial Journey Today",
-      href: "#",
+      href: "/sign-up",
     },
     subtext: "No credit card required, upgrade anytime",
   },
@@ -952,28 +751,28 @@ export const siteConfig = {
     {
       title: "Company",
       links: [
-        { id: 1, title: "About", url: "/waitlist" },
-        { id: 2, title: "Contact", url: "/waitlist" },
-        { id: 3, title: "Blog", url: "/waitlist" },
-        { id: 4, title: "Story", url: "/waitlist" },
+        { id: 1, title: "About", url: "/about" },
+        { id: 2, title: "Contact", url: "/contact" },
+        { id: 3, title: "Blog", url: "/blog" },
+        { id: 4, title: "Story", url: "/open" },
       ],
     },
     {
       title: "Products",
       links: [
-        { id: 5, title: "Company", url: "/waitlist" },
-        { id: 6, title: "Product", url: "/waitlist" },
+        { id: 5, title: "Platform", url: "/sign-up" },
+        { id: 6, title: "Dashboard", url: "/dashboard" },
         { id: 7, title: "Open Startup", url: "/open" },
-        { id: 8, title: "More", url: "/waitlist" },
+        { id: 8, title: "Community", url: "/community" },
       ],
     },
     {
       title: "Resources",
       links: [
-        { id: 9, title: "Press", url: "/waitlist" },
-        { id: 10, title: "Careers", url: "/waitlist" },
-        { id: 11, title: "Newsletters", url: "/waitlist" },
-        { id: 12, title: "More", url: "/waitlist" },
+        { id: 9, title: "Press", url: "/blog" },
+        { id: 10, title: "Careers", url: "/community" },
+        { id: 11, title: "Newsletter", url: "/blog" },
+        { id: 12, title: "Help Center", url: "/help" },
       ],
     },
   ],

--- a/src/lib/marketing-translations.tsx
+++ b/src/lib/marketing-translations.tsx
@@ -1,0 +1,485 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { siteConfig } from "@/lib/config";
+
+type MarketingLocale = "en" | "pt";
+
+type FeaturesContent = {
+  title: string;
+  description: string;
+  cards: {
+    eyebrow: string;
+    heading: string;
+    body: string;
+  }[];
+  highlight: {
+    description: string;
+    metrics: string[];
+  };
+};
+
+type PricingItem = (typeof siteConfig.pricing.pricingItems)[number] & {
+  included?: string | null;
+};
+
+type PricingContent = Omit<typeof siteConfig.pricing, "pricingItems"> & {
+  pricingItems: PricingItem[];
+};
+
+type MarketingContent = {
+  nav: typeof siteConfig.nav;
+  hero: typeof siteConfig.hero;
+  bentoSection: typeof siteConfig.bentoSection;
+  quoteSection: typeof siteConfig.quoteSection;
+  pricing: PricingContent;
+  faqSection: typeof siteConfig.faqSection;
+  ctaSection: typeof siteConfig.ctaSection;
+  footer: {
+    brand: string;
+    description: string;
+    columns: typeof siteConfig.footerLinks;
+    marquee: {
+      desktop: string;
+      mobile: string;
+    };
+  };
+  featuresSection: FeaturesContent;
+};
+
+const englishFeatures: FeaturesContent = {
+  title: "Tailored for Your Financial Success",
+  description:
+    "Every recommendation, insight, and suggestion is personalized to your unique financial situation and goals.",
+  cards: [
+    {
+      eyebrow: "Custom Budget Optimization",
+      heading: "AI creates budgets that actually work for your lifestyle, automatically adjusting to help you save more.",
+      body: "Get proactive recommendations on where to cut back, when to invest, and how to stretch every dollar further.",
+    },
+    {
+      eyebrow: "Behavioral Spending Insights",
+      heading: "Understand your spending patterns and discover optimization opportunities through AI-powered analysis.",
+      body: "Spot trends, receive alerts for unusual activity, and act on tailored suggestions that keep you on track.",
+    },
+  ],
+  highlight: {
+    description:
+      "AI-powered insights that adapt to your unique financial patterns and goals.",
+    metrics: ["Income", "Budget", "Savings", "Goals"],
+  },
+};
+
+const portugueseFeatures: FeaturesContent = {
+  title: "Planejada para o seu sucesso financeiro",
+  description:
+    "Cada recomendação, insight e sugestão é personalizada para a sua realidade financeira e seus objetivos.",
+  cards: [
+    {
+      eyebrow: "Otimização inteligente de orçamento",
+      heading:
+        "A IA cria orçamentos que funcionam para o seu estilo de vida, ajustando automaticamente para ajudar você a economizar mais.",
+      body: "Receba recomendações proativas sobre onde economizar, quando investir e como aproveitar melhor cada real.",
+    },
+    {
+      eyebrow: "Insights de comportamento de gastos",
+      heading:
+        "Entenda seus padrões de consumo e descubra oportunidades de otimização com análises impulsionadas por IA.",
+      body: "Identifique tendências, receba alertas sobre movimentações incomuns e siga sugestões sob medida para manter o controle.",
+    },
+  ],
+  highlight: {
+    description:
+      "Insights com IA que se adaptam aos seus padrões financeiros e metas.",
+    metrics: ["Renda", "Orçamento", "Poupança", "Metas"],
+  },
+};
+
+const englishContent: MarketingContent = {
+  nav: {
+    links: [
+      { id: 1, name: "Home", href: "#hero" },
+      { id: 2, name: "How it Works", href: "#bento" },
+      { id: 3, name: "Features", href: "#features" },
+      { id: 4, name: "Pricing", href: "#pricing" },
+      { id: 5, name: "Blog", href: "/blog" },
+      { id: 6, name: "Help", href: "/help" },
+    ],
+  },
+  hero: {
+    ...siteConfig.hero,
+    badge: "AI-powered financial insights",
+    title: "Master Your Money With AI",
+    description:
+      "Lyra-finAI turns raw transactions into real-time spending insights, predictive budgets, and a holistic financial health score. Spend smarter, save faster.",
+    cta: {
+      primary: { text: "Try for Free", href: "/sign-up" },
+      secondary: { text: "Sign In", href: "/sign-in" },
+    },
+  },
+  bentoSection: siteConfig.bentoSection,
+  quoteSection: {
+    ...siteConfig.quoteSection,
+    primaryButton: {
+      text: "Start Your Free Journey",
+      href: "/sign-up",
+    },
+  },
+  pricing: {
+    ...siteConfig.pricing,
+    pricingItems: siteConfig.pricing.pricingItems.map((tier) => {
+      if (tier.name === "Free") {
+        return { ...tier, href: "/sign-up", included: null };
+      }
+      if (tier.name === "Premium") {
+        return {
+          ...tier,
+          href: "/sign-up",
+          included: "Everything in Free +",
+        };
+      }
+      return {
+        ...tier,
+        href: "/sign-up",
+        included: "Everything in Premium +",
+      };
+    }),
+  },
+  faqSection: siteConfig.faqSection,
+  ctaSection: {
+    ...siteConfig.ctaSection,
+    button: {
+      text: "Start Your Free Financial Journey Today",
+      href: "/sign-up",
+    },
+  },
+  footer: {
+    brand: "Lyra-finAI",
+    description: siteConfig.hero.description,
+    columns: siteConfig.footerLinks,
+    marquee: {
+      desktop: "Lyra-finAI helps you grow wealth",
+      mobile: "Lyra-finAI",
+    },
+  },
+  featuresSection: englishFeatures,
+};
+
+const portugueseContent: MarketingContent = {
+  nav: {
+    links: [
+      { id: 1, name: "Início", href: "#hero" },
+      { id: 2, name: "Como Funciona", href: "#bento" },
+      { id: 3, name: "Recursos", href: "#features" },
+      { id: 4, name: "Planos", href: "#pricing" },
+      { id: 5, name: "Blog", href: "/blog" },
+      { id: 6, name: "Ajuda", href: "/help" },
+    ],
+  },
+  hero: {
+    ...siteConfig.hero,
+    badge: "Insights financeiros com IA",
+    title: "Domine seu dinheiro com IA",
+    description:
+      "Lyra-finAI transforma transações em insights de gastos em tempo real, orçamentos preditivos e um índice completo de saúde financeira.",
+    cta: {
+      primary: { text: "Experimente Grátis", href: "/sign-up" },
+      secondary: { text: "Entrar", href: "/sign-in" },
+    },
+  },
+  bentoSection: {
+    ...siteConfig.bentoSection,
+    title: "Potencialize suas finanças com IA",
+    description:
+      "Receba insights instantâneos de gastos, orçamentos preditivos e monitore sua saúde financeira em tempo real.",
+    items: siteConfig.bentoSection.items.map((item) => {
+      switch (item.id) {
+        case 1:
+          return {
+            ...item,
+            title: "Análise de gastos em tempo real",
+            description:
+              "Acompanhe cada transação na hora. Receba insights imediatos sobre padrões, gastos incomuns e desempenho do orçamento.",
+          };
+        case 2:
+          return {
+            ...item,
+            title: "Integração bancária segura",
+            description:
+              "Conecte todas as suas contas financeiras com segurança. Painel unificado para bancos, cartões, investimentos e cripto.",
+          };
+        case 3:
+          return {
+            ...item,
+            title: "Índice de saúde financeira",
+            description:
+              "Visualize sua saúde financeira de forma holística e acompanhe recomendações acionáveis para melhorar sua pontuação.",
+          };
+        case 4:
+          return {
+            ...item,
+            title: "Orçamento inteligente",
+            description:
+              "A IA cria e ajusta seu orçamento automaticamente. Receba alertas de excesso e dicas para manter o foco.",
+          };
+        default:
+          return item;
+      }
+    }),
+  },
+  quoteSection: {
+    ...siteConfig.quoteSection,
+    subtitle: "Transforme suas finanças.",
+    title: "Assuma o controle hoje",
+    description:
+      "Junte-se a milhares de usuários que melhoraram sua saúde financeira com insights de IA e orçamentos preditivos.",
+    primaryButton: {
+      text: "Comece sua jornada gratuita",
+      href: "/sign-up",
+    },
+    secondaryButton: {
+      ...siteConfig.quoteSection.secondaryButton,
+      text: "Fale com o fundador",
+    },
+  },
+  pricing: {
+    ...siteConfig.pricing,
+    title: "Planos que evoluem com você",
+    description:
+      "Comece grátis e faça upgrade quando precisar de mais recursos. Cancele quando quiser, sem taxas escondidas.",
+    pricingItems: siteConfig.pricing.pricingItems.map((tier) => {
+      const base = { ...tier, href: "/sign-up", included: null as string | null };
+      if (tier.name === "Free") {
+        return {
+          ...base,
+          name: "Gratuito",
+          buttonText: "Comece grátis",
+          description: "Ideal para começar a organizar suas finanças pessoais",
+          features: [
+            "Conecte até 2 contas",
+            "Insights básicos de gastos",
+            "Controle simples de orçamento",
+            "Pontuação mensal de saúde financeira",
+          ],
+        };
+      }
+      if (tier.name === "Premium") {
+        return {
+          ...base,
+          name: "Premium",
+          buttonText: "Assine o Premium",
+          description:
+            "Perfeito para pessoas e famílias que levam o controle financeiro a sério",
+          features: [
+            "Conexões ilimitadas de contas",
+            "Análises avançadas de gastos com IA",
+            "Orçamento preditivo e projeções",
+            "Alertas e notificações em tempo real",
+            "Monitoramento de investimentos",
+            "Metas financeiras personalizadas",
+            "Exportação de dados e relatórios",
+            "Suporte prioritário",
+          ],
+          included: "Tudo do Gratuito +",
+        };
+      }
+      return {
+        ...base,
+        name: "Família",
+        buttonText: "Plano Família",
+        description:
+          "Compartilhe com até 5 membros e mantenha todos alinhados aos objetivos financeiros",
+        features: [
+          "Até 5 perfis conectados",
+          "Metas colaborativas",
+          "Categorias personalizadas por membro",
+          "Alertas compartilhados de orçamento",
+          "Relatórios familiares",
+          "Gestão de assinaturas domésticas",
+          "Insights de poupança conjunta",
+          "Suporte dedicado",
+        ],
+        included: "Tudo do Premium +",
+      };
+    }),
+  },
+  faqSection: {
+    ...siteConfig.faqSection,
+    title: "Perguntas frequentes",
+    description:
+      "As respostas para as dúvidas mais comuns sobre a Lyra-finAI. Caso precise de algo mais, fale conosco.",
+    faQitems: siteConfig.faqSection.faQitems.map((item) => {
+      switch (item.id) {
+        case 1:
+          return {
+            ...item,
+            question: "O que é a Lyra-finAI?",
+            answer:
+              "A Lyra-finAI é uma plataforma de finanças pessoais com IA que transforma suas transações em insights acionáveis, cria orçamentos preditivos e calcula uma pontuação completa de saúde financeira.",
+          };
+        case 2:
+          return {
+            ...item,
+            question: "Como a Lyra-finAI analisa meus gastos?",
+            answer:
+              "Utilizamos algoritmos avançados para categorizar transações, identificar padrões de consumo, detectar movimentações incomuns e prever fluxo de caixa.",
+          };
+        case 3:
+          return {
+            ...item,
+            question: "Meus dados financeiros estão seguros?",
+            answer:
+              "Sim. Utilizamos criptografia de nível bancário, data centers seguros e nunca armazenamos suas credenciais. Seus dados são protegidos como nas grandes instituições financeiras.",
+          };
+        case 4:
+          return {
+            ...item,
+            question: "Quais bancos posso conectar?",
+            answer:
+              "Conecte-se a mais de 10.000 instituições, incluindo bancos, cooperativas, cartões de crédito, investimentos e carteiras cripto por meio de APIs seguras.",
+          };
+        case 5:
+          return {
+            ...item,
+            question: "Existe uma versão gratuita?",
+            answer:
+              "Sim. O plano gratuito oferece insights básicos de gastos, controle simples de orçamento e pontuação mensal de saúde financeira para até 2 contas.",
+          };
+        case 6:
+          return {
+            ...item,
+            question: "Como a Lyra-finAI me ajuda a economizar?",
+            answer:
+              "A plataforma identifica padrões de gastos, sugere ajustes de orçamento, avisa sobre despesas incomuns e prevê cenários futuros para você poupar mais.",
+          };
+        default:
+          return item;
+      }
+    }),
+  },
+  ctaSection: {
+    ...siteConfig.ctaSection,
+    title: "Planeje. Otimize. Prospere.",
+    button: {
+      text: "Crie sua conta gratuita",
+      href: "/sign-up",
+    },
+    subtext: "Sem cartão de crédito, faça upgrade quando quiser",
+  },
+  footer: {
+    brand: "Lyra-finAI",
+    description:
+      "Lyra-finAI transforma dados financeiros em decisões inteligentes com IA.",
+    columns: siteConfig.footerLinks.map((column) => {
+      if (column.title === "Company") {
+        return {
+          ...column,
+          title: "Empresa",
+          links: column.links.map((link) => {
+            const mapping: Record<number, string> = {
+              1: "Sobre",
+              2: "Contato",
+              3: "Blog",
+              4: "História",
+            };
+            return { ...link, title: mapping[link.id] ?? link.title };
+          }),
+        };
+      }
+      if (column.title === "Products") {
+        return {
+          ...column,
+          title: "Produtos",
+          links: column.links.map((link) => {
+            const mapping: Record<number, string> = {
+              5: "Plataforma",
+              6: "Dashboard",
+              7: "Open Startup",
+              8: "Comunidade",
+            };
+            return { ...link, title: mapping[link.id] ?? link.title };
+          }),
+        };
+      }
+      if (column.title === "Resources") {
+        return {
+          ...column,
+          title: "Recursos",
+          links: column.links.map((link) => {
+            const mapping: Record<number, string> = {
+              9: "Imprensa",
+              10: "Carreiras",
+              11: "Newsletter",
+              12: "Central de ajuda",
+            };
+            return { ...link, title: mapping[link.id] ?? link.title };
+          }),
+        };
+      }
+      return column;
+    }),
+    marquee: {
+      desktop: "Lyra-finAI cuida do seu futuro financeiro",
+      mobile: "Lyra-finAI",
+    },
+  },
+  featuresSection: portugueseFeatures,
+};
+
+const translations: Record<MarketingLocale, MarketingContent> = {
+  en: englishContent,
+  pt: portugueseContent,
+};
+
+type MarketingContextValue = {
+  locale: MarketingLocale;
+  setLocale: (locale: MarketingLocale) => void;
+  content: MarketingContent;
+};
+
+const MarketingContext = createContext<MarketingContextValue>({
+  locale: "en",
+  setLocale: () => undefined,
+  content: translations.en,
+});
+
+export function MarketingProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocaleState] = useState<MarketingLocale>("en");
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const stored = window.localStorage.getItem("lyra-marketing-locale") as MarketingLocale | null;
+    if (stored === "en" || stored === "pt") {
+      setLocaleState(stored);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem("lyra-marketing-locale", locale);
+  }, [locale]);
+
+  const value = useMemo(
+    () => ({
+      locale,
+      setLocale: setLocaleState,
+      content: translations[locale],
+    }),
+    [locale],
+  );
+
+  return <MarketingContext.Provider value={value}>{children}</MarketingContext.Provider>;
+}
+
+export function useMarketingContent() {
+  return useContext(MarketingContext).content;
+}
+
+export function useMarketingLocale() {
+  const { locale, setLocale } = useContext(MarketingContext);
+  return { locale, setLocale };
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,11 +1,11 @@
 export const siteConfig = {
-  name: "Badget",
-  url: "https://badget.tech",
+  name: "Lyra-finAI",
+  url: "https://lyra-finai.com",
   description:
     "AI-powered personal finance app that turns raw transactions into real-time spending insights, predictive budgets & holistic financial health scores.",
   links: {
     twitter: "https://x.com/codehagen",
-    github: "https://github.com/codehagen/badget",
+    github: "https://github.com/codehagen/lyra-finai",
   },
 };
 


### PR DESCRIPTION
## Summary
- added a marketing localization context and language switcher so the landing experience switches between English and Portuguese across navigation, hero, feature, FAQ, pricing, and footer copy
- wired primary calls-to-action to real sign-up and sign-in destinations, refreshed pricing plan buttons, and introduced a localized sign-up page so "Try for Free" flows work end-to-end
- rebranded the project to Lyra-finAI across configuration, metadata, documentation, and integration settings

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1649025a48323880a8e67fe567562