### PR TITLE
Configure Supabase as default database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database configuration
-DATABASE_URL="postgresql://username:password@localhost:5432/badget_dev"
+DATABASE_URL="postgresql://postgres:YOUR_SUPABASE_PASSWORD@YOUR_PROJECT_ID.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
+DIRECT_URL="postgresql://postgres:YOUR_SUPABASE_PASSWORD@YOUR_PROJECT_ID.supabase.co:5432/postgres"
 
 # Better Auth configuration
 BETTER_AUTH_SECRET="your_auth_secret_here"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Lyra-finAI implements a **dual-layer architecture** with clean separation betwee
 
 ## What we are using
 
-Next.js 15, Better-auth, Prisma, PostgreSQL, Shadcn/ui, Tailwind CSS, Framer Motion, and TypeScript.
+Next.js 15, Better-auth, Prisma with Supabase PostgreSQL, Shadcn/ui, Tailwind CSS, Framer Motion, and TypeScript.
 <br/>
 All seamlessly integrated to accelerate financial management innovation.
 
@@ -110,7 +110,7 @@ cp .env.example .env.local
 
    The `.env.example` file contains detailed explanations for each variable. Key requirements:
 
-   1. **Database**: We are using [Prisma Database](http://prisma.io/) (This is created over)  
+   1. **Database**: Provision a Supabase project and copy the `connection string` from Database > Connection pooling into `DATABASE_URL`. Copy the `Direct connection string` into `DIRECT_URL`. Both values must use the service role password so Prisma can run migrations. Supabase requires the pooled URL for the application runtime and the direct URL for schema changes.
    2. **Authentication**: Configure Better-auth OAuth providers
 
    **For Google Auth Setup:**
@@ -146,7 +146,7 @@ pnpm dev
 ### Platforms
 
 - [Vercel](https://vercel.com/) – Seamless deployment and preview environments
-- [Neon](https://neon.tech/) – Serverless PostgreSQL for scalable data management
+- [Supabase](https://supabase.com/) – Managed PostgreSQL with connection pooling and service role access
 - [Resend](https://resend.com/) – Reliable email delivery infrastructure
 
 ### UI & Design

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile
     environment:
       DATABASE_URL: postgresql://postgres:postgres@db:5432/badget
+      DIRECT_URL: postgresql://postgres:postgres@db:5432/badget
       BETTER_AUTH_SECRET: changeme
       BETTER_AUTH_URL: http://localhost:3000
       NEXT_PUBLIC_APP_URL: http://localhost:3000

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 // ---------- ENUMS ----------


### PR DESCRIPTION
## Summary
- set Supabase pooled and direct connection strings as the default database configuration
- document Supabase setup requirements in the installation guide and platform stack
- ensure local Docker environment exports DIRECT_URL for Prisma migrations

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d172319da083239eb6d80cadcb67b9